### PR TITLE
Add env file for Twitter credentials

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+TWITTER_CONSUMER_KEY=replace_with_your_key
+TWITTER_CONSUMER_SECRET=replace_with_your_secret

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ The Gradle wrapper JAR is also excluded to keep the repository free of binary
 artifacts. Running `./gradlew` will automatically download the required
 wrapper files.
 
+## Configuration
+
+Create a `.env` file in the repository root to provide your Twitter API
+credentials. It should contain the following keys:
+
+```
+TWITTER_CONSUMER_KEY=your_key
+TWITTER_CONSUMER_SECRET=your_secret
+```
+
+These values will be read by Gradle when building the app.
+
 To build the app:
 
 ```bash


### PR DESCRIPTION
## Summary
- add `.env` with placeholders for Twitter keys
- document `.env` usage in README

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68655371f8308327a39f438b6e8e43ce