### PR TITLE
Fix Twitter auth scheme mismatch

### DIFF
--- a/igtools_app/app/src/main/java/com/cicero/igtools/InstagramToolsFragment.kt
+++ b/igtools_app/app/src/main/java/com/cicero/igtools/InstagramToolsFragment.kt
@@ -295,7 +295,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                     .setOAuthConsumerSecret(BuildConfig.TWITTER_CONSUMER_SECRET)
                     .build()
                 twitter = TwitterFactory(config).instance
-                val reqToken = twitter?.getOAuthRequestToken("repostapp://twitter-callback")
+                val reqToken = twitter?.getOAuthRequestToken("igtools://twitter-callback")
                 if (reqToken != null) {
                     TwitterAuthManager.saveRequestToken(requireContext(), reqToken)
                 }


### PR DESCRIPTION
## Summary
- update OAuth callback URL to use `igtools` scheme

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_6865553446908327a56268da00f5c574