### PR TITLE
Simplify navigation and add Instagram OAuth login

### DIFF
--- a/socialtools_app/app/build.gradle.kts
+++ b/socialtools_app/app/build.gradle.kts
@@ -26,6 +26,8 @@ android {
         buildConfigField("String", "TWITTER_CONSUMER_SECRET", "\"${envProps["TWITTER_CONSUMER_SECRET"] ?: ""}\"")
         buildConfigField("String", "IG_GRAPH_TOKEN", "\"${envProps["IG_GRAPH_TOKEN"] ?: ""}\"")
         buildConfigField("String", "IG_GRAPH_USER_ID", "\"${envProps["IG_GRAPH_USER_ID"] ?: ""}\"")
+        buildConfigField("String", "IG_APP_ID", "\"${envProps["IG_APP_ID"] ?: ""}\"")
+        buildConfigField("String", "IG_REDIRECT_URI", "\"${envProps["IG_REDIRECT_URI"] ?: ""}\"")
     }
 
     buildFeatures {

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/InstaOauthLoginFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/InstaOauthLoginFragment.kt
@@ -1,0 +1,40 @@
+package com.cicero.socialtools
+
+import android.annotation.SuppressLint
+import android.net.Uri
+import android.os.Bundle
+import android.view.View
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+
+class InstaOauthLoginFragment : Fragment(R.layout.fragment_insta_oauth_login) {
+    @SuppressLint("SetJavaScriptEnabled")
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val webView = view.findViewById<WebView>(R.id.webview)
+        webView.settings.javaScriptEnabled = true
+
+        val clientId = BuildConfig.IG_APP_ID
+        val redirectUri = BuildConfig.IG_REDIRECT_URI
+        val authUrl = "https://api.instagram.com/oauth/authorize" +
+            "?client_id=$clientId&redirect_uri=$redirectUri&scope=user_profile" +
+            "&response_type=token"
+
+        webView.webViewClient = object : WebViewClient() {
+            override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
+                if (url != null && url.startsWith(redirectUri)) {
+                    val token = Uri.parse(url).fragment?.substringAfter("access_token=")
+                    if (!token.isNullOrEmpty()) {
+                        Toast.makeText(requireContext(), "Token: $token", Toast.LENGTH_SHORT).show()
+                    }
+                    return true
+                }
+                return false
+            }
+        }
+
+        webView.loadUrl(authUrl)
+    }
+}

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/MainActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/MainActivity.kt
@@ -13,10 +13,8 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
 
         val fragments = listOf<Fragment>(
-            DashboardFragment(),
-            InstaFragment(),
-            InstagramToolsFragment(),
-            ProfileFragment()
+            InstaOauthLoginFragment(),
+            InstagramToolsFragment()
         )
 
         val viewPager = findViewById<ViewPager2>(R.id.view_pager)
@@ -29,10 +27,8 @@ class MainActivity : AppCompatActivity() {
         val bottomNav = findViewById<BottomNavigationView>(R.id.bottom_navigation)
         bottomNav.setOnItemSelectedListener { item ->
             viewPager.currentItem = when (item.itemId) {
-                R.id.nav_dashboard -> 0
-                R.id.nav_insta -> 1
-                R.id.nav_instagram_tools -> 2
-                R.id.nav_profile -> 3
+                R.id.nav_insta_login -> 0
+                R.id.nav_instagram_tools -> 1
                 else -> 0
             }
             true
@@ -41,10 +37,8 @@ class MainActivity : AppCompatActivity() {
         viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 val selected = when (position) {
-                    0 -> R.id.nav_dashboard
-                    1 -> R.id.nav_insta
-                    2 -> R.id.nav_instagram_tools
-                    else -> R.id.nav_profile
+                    0 -> R.id.nav_insta_login
+                    else -> R.id.nav_instagram_tools
                 }
                 if (bottomNav.selectedItemId != selected) {
                     bottomNav.selectedItemId = selected
@@ -52,6 +46,6 @@ class MainActivity : AppCompatActivity() {
             }
         })
 
-        bottomNav.selectedItemId = R.id.nav_dashboard
+        bottomNav.selectedItemId = R.id.nav_insta_login
     }
 }

--- a/socialtools_app/app/src/main/res/layout/fragment_insta_oauth_login.xml
+++ b/socialtools_app/app/src/main/res/layout/fragment_insta_oauth_login.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <WebView
+        android:id="@+id/webview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</FrameLayout>

--- a/socialtools_app/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/socialtools_app/app/src/main/res/menu/bottom_nav_menu.xml
@@ -1,17 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:id="@+id/nav_dashboard"
-        android:icon="@android:drawable/ic_menu_view"
-        android:title="Dashboard" />
-    <item
-        android:id="@+id/nav_profile"
-        android:icon="@android:drawable/ic_menu_myplaces"
-        android:title="Profil" />
-    <item
-        android:id="@+id/nav_insta"
-        android:icon="@android:drawable/ic_menu_gallery"
-        android:title="Konten" />
+        android:id="@+id/nav_insta_login"
+        android:icon="@android:drawable/ic_menu_add"
+        android:title="Login" />
     <item
         android:id="@+id/nav_instagram_tools"
         android:icon="@android:drawable/ic_menu_edit"


### PR DESCRIPTION
## Summary
- update main menu and navigation to only include IG login and tools
- add `InstaOauthLoginFragment` with WebView-based OAuth flow
- expose IG OAuth config via `BuildConfig`

## Testing
- `./socialtools_app/gradlew assembleDebug` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_68660e1ac5d8832796308d338382a11a