### PR TITLE
Add flare target usernames

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/InstaFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/InstaFragment.kt
@@ -2,4 +2,18 @@ package com.cicero.socialtools
 
 import androidx.fragment.app.Fragment
 
-class InstaFragment : Fragment(R.layout.fragment_insta)
+class InstaFragment : Fragment(R.layout.fragment_insta) {
+    private val flareTargets = listOf(
+        "respaskot",
+        "polresblitarofficial",
+        "polres_ponorogo",
+        "polreskediriofficial",
+        "ditlantaspoldajatim",
+        "humaspoldajatim",
+        "ditlantas_poldariau",
+        "ditlantaspoldajateng",
+        "divhumaspolri",
+        "divpropampolri",
+        "divtikpolri"
+    )
+}


### PR DESCRIPTION
## Summary
- add flare target username list in `InstaFragment`

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686616e3be788327a54621bdf5d2684b