### PR TITLE
Implement PostService background worker

### DIFF
--- a/socialtools_app/app/src/main/AndroidManifest.xml
+++ b/socialtools_app/app/src/main/AndroidManifest.xml
@@ -34,5 +34,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".PostService"
+            android:exported="false" />
     </application>
 </manifest>

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/MainActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.cicero.socialtools
 
 import android.os.Bundle
+import android.content.Intent
+import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -10,6 +12,7 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        startPostService()
         setContentView(R.layout.activity_main)
 
         val fragments = listOf<Fragment>(
@@ -47,5 +50,14 @@ class MainActivity : AppCompatActivity() {
         })
 
         bottomNav.selectedItemId = R.id.nav_insta_login
+    }
+
+    private fun startPostService() {
+        val intent = Intent(this, PostService::class.java)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundService(intent)
+        } else {
+            startService(intent)
+        }
     }
 }

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/PostService.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/PostService.kt
@@ -1,0 +1,62 @@
+package com.cicero.socialtools
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import android.util.Log
+import kotlinx.coroutines.*
+
+class PostService : Service() {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onCreate() {
+        super.onCreate()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Post Service",
+                NotificationManager.IMPORTANCE_LOW
+            )
+            val mgr = getSystemService(NotificationManager::class.java)
+            mgr.createNotificationChannel(channel)
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Social Tools")
+            .setContentText("Layanan berjalan di latar belakang")
+            .setSmallIcon(R.drawable.ic_status_true)
+            .build()
+        startForeground(1, notification)
+
+        scope.launch { runAutopost() }
+        return START_STICKY
+    }
+
+    private suspend fun runAutopost() {
+        val delays = listOf(1000L, 2000L, 3000L)
+        for ((index, d) in delays.withIndex()) {
+            Log.d("PostService", "Process ${index + 1} delay: ${d}ms")
+            delay(d)
+            Log.d("PostService", "Process ${index + 1} executed")
+        }
+        stopSelf()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "post_service"
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `PostService` that runs as a foreground service and logs delays for its work
- start the service from `MainActivity`
- register the service in the manifest

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686625a59e4083278d6427e6688afde6