### PR TITLE
Add foreground service permission

### DIFF
--- a/socialtools_app/app/src/main/AndroidManifest.xml
+++ b/socialtools_app/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest package="com.cicero.socialtools"
     xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Required for starting foreground services on Android 9+ -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <application
         android:name=".App"
         android:allowBackup="true"


### PR DESCRIPTION
## Summary
- fix security exception by adding `FOREGROUND_SERVICE` permission

## Testing
- `gradle test` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_686629f95cdc832789e9cc273778b383