### PR TITLE
Add AI-driven Instagram comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ credentials. It should contain the following keys:
 ```
 TWITTER_CONSUMER_KEY=your_key
 TWITTER_CONSUMER_SECRET=your_secret
+OPENAI_API_KEY=sk-...
 ```
 
 These values will be read by Gradle when building the app.

--- a/socialtools_app/app/build.gradle.kts
+++ b/socialtools_app/app/build.gradle.kts
@@ -28,6 +28,7 @@ android {
         buildConfigField("String", "IG_GRAPH_USER_ID", "\"${envProps["IG_GRAPH_USER_ID"] ?: ""}\"")
         buildConfigField("String", "IG_APP_ID", "\"${envProps["IG_APP_ID"] ?: ""}\"")
         buildConfigField("String", "IG_REDIRECT_URI", "\"${envProps["IG_REDIRECT_URI"] ?: ""}\"")
+        buildConfigField("String", "OPENAI_API_KEY", "\"${envProps["OPENAI_API_KEY"] ?: ""}\"")
     }
 
     buildFeatures {


### PR DESCRIPTION
## Summary
- add OpenAI API key config
- document new env var
- implement `fetchAiComment` to generate comments from post captions
- use `fetchAiComment` during comment routine

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686632236a048327949a127cca3f9ac4