### PR TITLE
Show captions during comment routine

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/InstagramToolsFragment.kt
@@ -857,6 +857,9 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                 for (post in posts) {
                     val code = post.code
                     val id = post.id
+                    post.caption?.let {
+                        appendLog("> caption: ${'$'}it", animate = true)
+                    }
                     commentFlareAccounts(client, 5)
                     val text = withContext(Dispatchers.IO) {
                         fetchAiComment(post.caption ?: "") ?: fetchRandomQuote()


### PR DESCRIPTION
## Summary
- show the post caption when commenting on Instagram posts

## Testing
- `./socialtools_app/gradlew tasks --no-daemon` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_68663758ac148327b8a992ae29f5f864