### PR TITLE
Show captions when logging fetched IG posts

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/InstagramToolsFragment.kt
@@ -806,6 +806,12 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                     "> found post: https://instagram.com/p/$code",
                     animate = true
                 )
+                post.caption?.let {
+                    appendLog(
+                        "> caption: $it",
+                        animate = true
+                    )
+                }
                 delay(500)
             }
             appendLog(


### PR DESCRIPTION
## Summary
- include captions while logging fetched Instagram posts

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866424011a48327bda6446cceec117a