### PR TITLE
Fix README .env location

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ wrapper files.
 
 ## Configuration
 
-Create a `.env` file in the repository root to provide your Twitter API
-credentials. It should contain the following keys:
+Create a `.env` file inside the `socialtools_app` directory (the Gradle
+project root) to provide your Twitter API credentials. It should contain the
+following keys:
 
 ```
 TWITTER_CONSUMER_KEY=your_key


### PR DESCRIPTION
## Summary
- clarify `.env` location for Gradle build

## Testing
- `./gradlew tasks` *(fails: unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686652e38064832789a2fc47a7bd892b