### PR TITLE
Use Android device info in instagram4j login

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/InstagramToolsFragment.kt
@@ -14,9 +14,14 @@ import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
 import android.util.Log
+import android.provider.Settings
+import android.webkit.WebSettings
+import android.os.Build
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import com.github.instagram4j.instagram4j.exceptions.IGResponseException
+import com.github.instagram4j.instagram4j.responses.accounts.LoginResponse
 import com.bumptech.glide.Glide
 import com.github.instagram4j.instagram4j.IGClient
 import com.github.instagram4j.instagram4j.IGClient.Builder.LoginHandler
@@ -217,6 +222,48 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
     }
 
 
+    private fun loginWithDeviceInfo(
+        user: String,
+        pass: String,
+        twoFactorHandler: LoginHandler,
+        challengeHandler: LoginHandler
+    ): IGClient {
+        val androidId = Settings.Secure.getString(requireContext().contentResolver, Settings.Secure.ANDROID_ID)
+        val userAgent = WebSettings.getDefaultUserAgent(requireContext())
+        val device = IGDevice(userAgent, IGAndroidDevice.CAPABILITIES, emptyMap())
+
+        val client = IGClient.builder()
+            .username(user)
+            .password(pass)
+            .device(device)
+            .build()
+
+        runCatching {
+            val field = IGClient::class.java.getDeclaredField("deviceId")
+            field.isAccessible = true
+            field.set(client, androidId)
+        }
+
+        val response = client.sendLoginRequest()
+            .exceptionally { tr ->
+                var login = IGResponseException.IGFailedResponse.of(tr.cause, LoginResponse::class.java)
+                if (login.two_factor_info != null) {
+                    login = twoFactorHandler.accept(client, login)
+                }
+                if (login.challenge != null) {
+                    login = challengeHandler.accept(client, login)
+                    client.setLoggedInState(login)
+                }
+                login
+            }.join()
+
+        if (!client.isLoggedIn) {
+            throw IGLoginException(client, response)
+        }
+
+        return client
+    }
+
 
     private fun performLogin(user: String, pass: String) {
         CoroutineScope(Dispatchers.IO).launch {
@@ -232,12 +279,12 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
             }
 
             try {
-                val client = IGClient.builder()
-                    .username(user)
-                    .password(pass)
-                    .onTwoFactor(twoFactorHandler)
-                    .onChallenge(challengeHandler)
-                    .login()
+                val client = loginWithDeviceInfo(
+                    user,
+                    pass,
+                    twoFactorHandler,
+                    challengeHandler
+                )
                 client.serialize(clientFile, cookieFile)
                 val info = client.actions().users().info(client.selfProfile.pk).join()
                 withContext(Dispatchers.Main) {


### PR DESCRIPTION
## Summary
- pull Android `deviceId` via `Settings.Secure` and default user agent
- login to Instagram using the custom device data

## Testing
- `gradle wrapper --gradle-version 8.7`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68665c235668832795350a478ba74279