### PR TITLE
Fix missing IG device imports

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/InstagramToolsFragment.kt
@@ -25,6 +25,8 @@ import com.github.instagram4j.instagram4j.responses.accounts.LoginResponse
 import com.bumptech.glide.Glide
 import com.github.instagram4j.instagram4j.IGClient
 import com.github.instagram4j.instagram4j.IGClient.Builder.LoginHandler
+import com.github.instagram4j.instagram4j.IGDevice
+import com.github.instagram4j.instagram4j.IGAndroidDevice
 import com.github.instagram4j.instagram4j.actions.timeline.TimelineAction
 import com.github.instagram4j.instagram4j.exceptions.IGLoginException
 import com.cicero.socialtools.BuildConfig


### PR DESCRIPTION
## Summary
- add missing imports for IGDevice and IGAndroidDevice in InstagramToolsFragment

## Testing
- `./gradlew --version` *(fails: no main manifest attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68666148c9cc832786ac8a3ed89c6ba2