### PR TITLE
Improve OpenAI error logging

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/InstagramToolsFragment.kt
@@ -1080,7 +1080,8 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                     ?.trim()
             }
         } catch (e: Exception) {
-            appendLog("> OpenAI call error: ${'$'}{e.javaClass.simpleName}: ${'$'}{e.message}")
+            val details = e.stackTraceToString()
+            appendLog("> OpenAI call error: ${'$'}{e.javaClass.simpleName}: ${'$'}{e.message}\n$details")
             Log.e("InstagramToolsFragment", "OpenAI call error", e)
             null
         }


### PR DESCRIPTION
## Summary
- show full stack trace for OpenAI call errors for easier debugging

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667c059b388327aebf96c0ebb8402b