### PR TITLE
Default IG tools options unchecked

### DIFF
--- a/socialtools_app/app/src/main/res/layout/fragment_instagram_tools.xml
+++ b/socialtools_app/app/src/main/res/layout/fragment_instagram_tools.xml
@@ -117,14 +117,14 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Likes"
-                android:checked="true" />
+                android:checked="false" />
 
             <CheckBox
                 android:id="@+id/checkbox_repost"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Repost"
-                android:checked="true"
+                android:checked="false"
                 android:layout_marginStart="16dp" />
 
             <CheckBox
@@ -132,7 +132,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="Komentar"
-                android:checked="true"
+                android:checked="false"
                 android:layout_marginStart="16dp" />
         </LinearLayout>
 


### PR DESCRIPTION
## Summary
- set the Like, Repost and Comment checkboxes to unchecked by default in Instagram tools

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68667d2d89d08327971a7c419d1e38cc