### PR TITLE
Simplify MainActivity layout

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/MainActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/MainActivity.kt
@@ -4,10 +4,6 @@ import android.os.Bundle
 import android.content.Intent
 import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
-import androidx.viewpager2.widget.ViewPager2
-import com.google.android.material.bottomnavigation.BottomNavigationView
-import androidx.fragment.app.Fragment
-import androidx.viewpager2.adapter.FragmentStateAdapter
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -15,41 +11,11 @@ class MainActivity : AppCompatActivity() {
         startPostService()
         setContentView(R.layout.activity_main)
 
-        val fragments = listOf<Fragment>(
-            InstaOauthLoginFragment(),
-            InstagramToolsFragment()
-        )
-
-        val viewPager = findViewById<ViewPager2>(R.id.view_pager)
-        viewPager.adapter = object : FragmentStateAdapter(this) {
-            override fun getItemCount() = fragments.size
-            override fun createFragment(position: Int) = fragments[position]
+        if (savedInstanceState == null) {
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.fragment_container, InstagramToolsFragment())
+                .commit()
         }
-        viewPager.isUserInputEnabled = false
-
-        val bottomNav = findViewById<BottomNavigationView>(R.id.bottom_navigation)
-        bottomNav.setOnItemSelectedListener { item ->
-            viewPager.currentItem = when (item.itemId) {
-                R.id.nav_insta_login -> 0
-                R.id.nav_instagram_tools -> 1
-                else -> 0
-            }
-            true
-        }
-
-        viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
-            override fun onPageSelected(position: Int) {
-                val selected = when (position) {
-                    0 -> R.id.nav_insta_login
-                    else -> R.id.nav_instagram_tools
-                }
-                if (bottomNav.selectedItemId != selected) {
-                    bottomNav.selectedItemId = selected
-                }
-            }
-        })
-
-        bottomNav.selectedItemId = R.id.nav_insta_login
     }
 
     private fun startPostService() {

--- a/socialtools_app/app/src/main/res/layout/activity_main.xml
+++ b/socialtools_app/app/src/main/res/layout/activity_main.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <androidx.viewpager2.widget.ViewPager2
-        android:id="@+id/view_pager"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1" />
-
-    <com.google.android.material.bottomnavigation.BottomNavigationView
-        android:id="@+id/bottom_navigation"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:menu="@menu/bottom_nav_menu" />
-</LinearLayout>
+    android:layout_height="match_parent" />


### PR DESCRIPTION
## Summary
- use FrameLayout in `activity_main.xml`
- simplify `MainActivity` to show `InstagramToolsFragment` directly

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68668bca49a88327959d8bffcf9b2094