### PR TITLE
Remove viewpager dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ The Gradle wrapper JAR is also excluded to keep the repository free of binary
 artifacts. Running `./gradlew` will automatically download the required
 wrapper files.
 
+The app now opens straight to the Instagram tools screen. The previous
+ViewPager navigation has been removed so users are taken directly to the IG
+automation interface on launch.
+
 ## Configuration
 
 Create a `.env` file in the repository root to provide your Twitter API

--- a/socialtools_app/app/build.gradle.kts
+++ b/socialtools_app/app/build.gradle.kts
@@ -59,7 +59,6 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     implementation("androidx.fragment:fragment-ktx:1.6.2")
-    implementation("androidx.viewpager2:viewpager2:1.0.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("com.github.bumptech.glide:glide:4.16.0")
     implementation("com.github.instagram4j:instagram4j:2.0.7")


### PR DESCRIPTION
## Summary
- drop the unused ViewPager2 dependency
- note in README that the app launches directly to the IG tools screen

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_686691eecae08327baba4370672d0f03