### PR TITLE
Add console loading demo

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/PostService.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/PostService.kt
@@ -9,6 +9,7 @@ import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import android.util.Log
 import com.cicero.socialtools.R
+import com.cicero.socialtools.utils.ConsoleLoading
 import kotlinx.coroutines.*
 
 class PostService : Service() {
@@ -40,6 +41,7 @@ class PostService : Service() {
     }
 
     private suspend fun runAutopost() {
+        ConsoleLoading.showLoading(tag = "PostService")
         val delays = listOf(1000L, 2000L, 3000L)
         for ((index, d) in delays.withIndex()) {
             Log.d("PostService", "Process ${index + 1} delay: ${d}ms")

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/utils/ConsoleLoading.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/utils/ConsoleLoading.kt
@@ -1,0 +1,24 @@
+package com.cicero.socialtools.utils
+
+import android.util.Log
+
+/** Utility to demonstrate a loading progress in the console log. */
+object ConsoleLoading {
+    /**
+     * Log a simple loading progress from 0% to 100%.
+     * This is useful for showing long-running tasks in logcat.
+     */
+    fun showLoading(tag: String = "ConsoleLoading", steps: Int = 10, delayMillis: Long = 300) {
+        for (i in 1..steps) {
+            val percent = i * 100 / steps
+            Log.d(tag, "Loading... $percent%")
+            try {
+                Thread.sleep(delayMillis)
+            } catch (e: InterruptedException) {
+                Log.d(tag, "Interrupted", e)
+                return
+            }
+        }
+        Log.d(tag, "Loading complete")
+    }
+}


### PR DESCRIPTION
## Summary
- add new `ConsoleLoading` util
- show loading in `PostService` before autopost steps

## Testing
- `./socialtools_app/gradlew test --no-daemon` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_6866acd44d408327983ab247da359311