### PR TITLE
Fix log animation freeze

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -492,7 +492,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
         }
         logContainer.addView(tv)
         CoroutineScope(Dispatchers.Main).launch {
-            if (animate) {
+            if (animate && text.length <= 100) {
                 for (c in text) {
                     tv.append(c.toString())
                     delay(30)


### PR DESCRIPTION
## Summary
- avoid long delays for large log entries by limiting animation

## Testing
- `./socialtools_app/gradlew -p socialtools_app assembleDebug` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_6866aca2af4483279ef89ec1939bd78a