### PR TITLE
Add trash icon overlay in console

### DIFF
--- a/socialtools_app/app/src/main/res/layout/fragment_instagram_tools.xml
+++ b/socialtools_app/app/src/main/res/layout/fragment_instagram_tools.xml
@@ -181,29 +181,34 @@
             android:text="Start"
             android:layout_margin="16dp" />
 
-        <ImageButton
-            android:id="@+id/button_clear_logs"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:src="@drawable/ic_clear_log"
-            android:contentDescription="@string/clear_logs"
-            android:layout_marginEnd="16dp" />
-
-        <ScrollView
-            android:id="@+id/log_scroll"
+        <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1"
-            android:background="@drawable/console_frame"
-            android:padding="8dp">
+            android:layout_weight="1">
 
-            <LinearLayout
-                android:id="@+id/log_container"
-                android:orientation="vertical"
+            <ScrollView
+                android:id="@+id/log_scroll"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-        </ScrollView>
+                android:layout_height="match_parent"
+                android:background="@drawable/console_frame"
+                android:padding="8dp">
+
+                <LinearLayout
+                    android:id="@+id/log_container"
+                    android:orientation="vertical"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </ScrollView>
+
+            <ImageButton
+                android:id="@+id/button_clear_logs"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end|top"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:src="@drawable/ic_clear_log"
+                android:contentDescription="@string/clear_logs"
+                android:layout_margin="4dp" />
+        </FrameLayout>
     </LinearLayout>
 </FrameLayout>


### PR DESCRIPTION
## Summary
- move clear logs button inside the console ScrollView
- overlay the button in the top-right corner so it's always visible

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_6867222324788327b3910c4e7c7d25d0