### PR TITLE
Fix runtime OpenAI key usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ TWITTER_CONSUMER_SECRET=your_secret
 OPENAI_API_KEY=sk-...
 ```
 
-These values will be read by Gradle when building the app.
+These values will be read by Gradle when building the app. If the OpenAI key is
+not provided at build time, the app also checks the `OPENAI_API_KEY` environment
+variable at runtime when generating comments.
 
 To build the app:
 

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -1022,7 +1022,9 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
     }
 
     private fun fetchAiComment(caption: String): String? {
-        val apiKey = BuildConfig.OPENAI_API_KEY
+        val apiKey = BuildConfig.OPENAI_API_KEY.ifBlank {
+            System.getenv("OPENAI_API_KEY") ?: ""
+        }
         if (apiKey.isBlank()) {
             appendLog("> AI comment skipped: API key blank")
             Log.d("InstagramToolsFragment", "OpenAI API key is blank")


### PR DESCRIPTION
## Summary
- look for OPENAI_API_KEY env var at runtime
- document runtime OpenAI key fallback in README

## Testing
- `bash -x ./gradlew --version` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_6867242bdef08327b2bfa77a2b2ab0ec