### PR TITLE
Fix UI updates from background thread

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -460,12 +460,12 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
         appendToFile: Boolean = true,
         animate: Boolean = false
     ) {
-        val tv = TextView(requireContext()).apply {
-            typeface = android.graphics.Typeface.MONOSPACE
-            setTextColor(android.graphics.Color.parseColor("#00FF00"))
-        }
-        logContainer.addView(tv)
-        CoroutineScope(Dispatchers.Main).launch {
+        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
+            val tv = TextView(requireContext()).apply {
+                typeface = android.graphics.Typeface.MONOSPACE
+                setTextColor(android.graphics.Color.parseColor("#00FF00"))
+            }
+            logContainer.addView(tv)
             if (animate && text.length <= 100) {
                 for (c in text) {
                     tv.append(c.toString())


### PR DESCRIPTION
## Summary
- use viewLifecycleOwner.lifecycleScope on appendLog so UI updates happen on the main thread

## Testing
- `gradle test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686756d2a0488327b85b22f6e3b7e9ed