### PR TITLE
Add AI comment check screen

### DIFF
--- a/docs/AI_COMMENT_TEST_SCENARIO.md
+++ b/docs/AI_COMMENT_TEST_SCENARIO.md
@@ -1,0 +1,11 @@
+# AI Comment Generation Check
+
+This page describes how to verify that comment generation via OpenAI works inside the app.
+
+## Steps
+1. Launch the app and log in to Instagram as usual.
+2. Tap the menu icon and select **Check AI Comment**.
+3. In the test screen enter any caption text then tap **Generate Comment**.
+4. The app calls the OpenAI API and displays the generated comment or an error message.
+
+If a comment is returned, the integration is working correctly.

--- a/socialtools_app/app/src/main/AndroidManifest.xml
+++ b/socialtools_app/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".ui.AiCommentCheckActivity" android:exported="false" />
         <service
             android:name=".core.services.PostService"
             android:exported="false" />

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -1116,6 +1116,10 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                 }
                 true
             }
+            R.id.action_check_ai -> {
+                startActivity(Intent(requireContext(), com.cicero.socialtools.ui.AiCommentCheckActivity::class.java))
+                true
+            }
             else -> super.onOptionsItemSelected(item)
         }
     }

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/AiCommentCheckActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/AiCommentCheckActivity.kt
@@ -1,0 +1,79 @@
+package com.cicero.socialtools.ui
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import com.cicero.socialtools.BuildConfig
+import com.cicero.socialtools.R
+import com.cicero.socialtools.utils.OpenAiUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+
+/** Simple screen to test AI comment generation using OpenAI. */
+class AiCommentCheckActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_ai_comment_check)
+
+        val input = findViewById<EditText>(R.id.input_caption)
+        val result = findViewById<TextView>(R.id.text_result)
+        val button = findViewById<Button>(R.id.button_generate)
+
+        button.setOnClickListener {
+            result.text = getString(R.string.loading)
+            val caption = input.text.toString()
+            CoroutineScope(Dispatchers.IO).launch {
+                val comment = fetchAiComment(caption)
+                withContext(Dispatchers.Main) {
+                    result.text = comment ?: getString(R.string.error_generating_comment)
+                }
+            }
+        }
+    }
+
+    private fun fetchAiComment(caption: String): String? {
+        val apiKey = BuildConfig.OPENAI_API_KEY.ifBlank {
+            System.getenv("OPENAI_API_KEY") ?: ""
+        }
+        if (apiKey.isBlank() || caption.isBlank()) return null
+
+        val json = OpenAiUtils.buildRequestJson(caption)
+        val client = OkHttpClient()
+        val req = Request.Builder()
+            .url("https://api.openai.com/v1/chat/completions")
+            .header("Authorization", "Bearer $apiKey")
+            .header("Content-Type", "application/json")
+            .post(json.toRequestBody("application/json; charset=utf-8".toMediaType()))
+            .build()
+        return try {
+            client.newCall(req).execute().use { resp ->
+                val bodyStr = resp.body?.string()
+                if (!resp.isSuccessful) return null
+                val obj = JSONObject(bodyStr ?: "{}")
+                val text = obj.getJSONArray("choices")
+                    .optJSONObject(0)
+                    ?.optJSONObject("message")
+                    ?.optString("content")
+                    ?.trim()
+                text?.let { limitWords(it, 15) }
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun limitWords(text: String, maxWords: Int): String {
+        val words = text.split(Regex("\\s+")).filter { it.isNotBlank() }
+        return words.take(maxWords).joinToString(" ").trim()
+    }
+}

--- a/socialtools_app/app/src/main/res/layout/activity_ai_comment_check.xml
+++ b/socialtools_app/app/src/main/res/layout/activity_ai_comment_check.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Caption">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/input_caption"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <Button
+        android:id="@+id/button_generate"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/generate_comment" />
+
+    <TextView
+        android:id="@+id/text_result"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:textColor="@android:color/black" />
+
+</LinearLayout>

--- a/socialtools_app/app/src/main/res/menu/menu_instagram_profile.xml
+++ b/socialtools_app/app/src/main/res/menu/menu_instagram_profile.xml
@@ -6,4 +6,8 @@
         android:title="Logout"
         android:showAsAction="ifRoom" />
     <!-- Removed premium registration and confirmation actions -->
+    <item
+        android:id="@+id/action_check_ai"
+        android:title="@string/check_ai_comment"
+        android:showAsAction="never" />
 </menu>

--- a/socialtools_app/app/src/main/res/values/strings.xml
+++ b/socialtools_app/app/src/main/res/values/strings.xml
@@ -29,4 +29,7 @@
     <string name="start">Start</string>
     <string name="clear_logs">Clear Logs</string>
     <string name="whatsapp_message_registration">Halo,\nTerima kasih telah menggunakan aplikasi Social Tools.\n\nBerikut panduan registrasi ulang:\n1. Buka Wabot lalu kirim perintah /register.\n2. Masukkan NRP dan nomor WhatsApp Anda.\n3. Tunggu konfirmasi dari admin.\n\nUntuk menambahkan akun Instagram dan TikTok via Wabot:\n1. Kirim perintah /add_instagram &lt;username&gt;.\n2. Kirim perintah /add_tiktok &lt;username&gt;.\n\nTerima kasih.</string>
+    <string name="generate_comment">Generate Comment</string>
+    <string name="error_generating_comment">Failed to generate comment</string>
+    <string name="check_ai_comment">Check AI Comment</string>
 </resources>


### PR DESCRIPTION
## Summary
- add AiCommentCheckActivity with layout to test OpenAI comment generation
- expose the test screen from Instagram menu
- register new activity in manifest
- document scenario for verifying AI comment generation

## Testing
- `./gradlew test` *(fails: unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68675aa3baa88327aefa4c1f3a472b48