### PR TITLE
Log raw OpenAI response

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/AiCommentCheckActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/AiCommentCheckActivity.kt
@@ -1,6 +1,7 @@
 package com.cicero.socialtools.ui
 
 import android.os.Bundle
+import android.util.Log
 import android.widget.Button
 import android.widget.EditText
 import android.widget.TextView
@@ -61,8 +62,10 @@ class AiCommentCheckActivity : AppCompatActivity() {
             client.newCall(req).execute().use { resp ->
                 val bodyStr = resp.body?.string()
                 if (!resp.isSuccessful) {
-                    return "Error ${resp.code}: ${bodyStr?.take(200)}"
+                    Log.d("AiCommentCheck", "Error ${'$'}{resp.code} response: ${'$'}{bodyStr}")
+                    return "Error ${'$'}{resp.code}: ${'$'}{bodyStr?.take(200)}"
                 }
+                Log.d("AiCommentCheck", "Raw response: ${'$'}bodyStr")
                 val obj = JSONObject(bodyStr ?: "{}")
                 val text = obj.getJSONArray("choices")
                     .optJSONObject(0)


### PR DESCRIPTION
## Summary
- log raw OpenAI API responses in `AiCommentCheckActivity`

## Testing
- `gradle test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b1bc557c8327bd202da64c3edd13