### PR TITLE
Add process timing and improve AI comment feedback

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -85,6 +85,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
     private lateinit var postsView: TextView
     private lateinit var followersView: TextView
     private lateinit var followingView: TextView
+    private lateinit var processTimeView: TextView
     // Removed Twitter and TikTok UI elements
     private lateinit var targetLinkInput: EditText
     private val repostedIds = mutableSetOf<String>()
@@ -97,6 +98,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
     private var userId: String = ""
     private var targetUsername: String = "polres_ponorogo"
     private var isPremium: Boolean = false
+    private var startTimeMs: Long = 0L
     private val flareTargets = listOf(
         "respaskot",
         "humas.polresblitar",
@@ -184,6 +186,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
         logContainer = view.findViewById(R.id.log_container)
         logScroll = view.findViewById(R.id.log_scroll)
         clearLogsButton = view.findViewById(R.id.button_clear_logs)
+        processTimeView = view.findViewById(R.id.text_process_time)
 
         clearLogsButton.setOnClickListener { clearLogs() }
 
@@ -205,6 +208,9 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                 return@setOnClickListener
             }
             targetUsername = parseUsername(target)
+
+            startTimeMs = System.currentTimeMillis()
+            processTimeView.text = getString(R.string.loading)
 
             val doLike = likeCheckbox.isChecked
             val doRepost = repostCheckbox.isChecked
@@ -883,6 +889,8 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                 )
                 Log.d("InstagramToolsFragment", "Start reposting posts")
                 launchRepostSequence(client, posts)
+            } else {
+                withContext(Dispatchers.Main) { onProcessComplete() }
             }
         }
     }
@@ -938,6 +946,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                 ">>> Repost routine complete.",
                 animate = true
             )
+            withContext(Dispatchers.Main) { onProcessComplete() }
         }
     }
 
@@ -1085,6 +1094,12 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
     private fun limitWords(text: String, maxWords: Int): String {
         val words = text.split(Regex("\\s+")).filter { it.isNotBlank() }
         return words.take(maxWords).joinToString(" ").trim()
+    }
+
+    private fun onProcessComplete() {
+        val elapsed = System.currentTimeMillis() - startTimeMs
+        val seconds = (elapsed / 1000).toInt()
+        processTimeView.text = getString(R.string.process_time_result, seconds)
     }
 
 

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/AiCommentCheckActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/AiCommentCheckActivity.kt
@@ -46,8 +46,11 @@ class AiCommentCheckActivity : AppCompatActivity() {
         val apiKey = BuildConfig.OPENAI_API_KEY.ifBlank {
             System.getenv("OPENAI_API_KEY") ?: ""
         }
-        if (apiKey.isBlank() || caption.isBlank()) {
-            return getString(R.string.error_generating_comment)
+        if (apiKey.isBlank()) {
+            return "API key missing"
+        }
+        if (caption.isBlank()) {
+            return "Caption empty"
         }
 
         val json = OpenAiUtils.buildRequestJson(caption)
@@ -63,7 +66,7 @@ class AiCommentCheckActivity : AppCompatActivity() {
                 val bodyStr = resp.body?.string()
                 if (!resp.isSuccessful) {
                     Log.d("AiCommentCheck", "Error ${'$'}{resp.code} response: ${'$'}{bodyStr}")
-                    return "Error ${'$'}{resp.code}: ${'$'}{bodyStr?.take(200)}"
+                    return "Error ${'$'}{resp.code}: ${'$'}{bodyStr}".trim()
                 }
                 Log.d("AiCommentCheck", "Raw response: ${'$'}bodyStr")
                 val obj = JSONObject(bodyStr ?: "{}")
@@ -72,7 +75,10 @@ class AiCommentCheckActivity : AppCompatActivity() {
                     ?.optJSONObject("message")
                     ?.optString("content")
                     ?.trim()
-                text?.let { limitWords(it, 15) } ?: getString(R.string.error_generating_comment)
+                if (text.isNullOrBlank()) {
+                    return "Raw response: ${'$'}{bodyStr?.take(200)}"
+                }
+                limitWords(text, 15)
             }
         } catch (e: Exception) {
             "Exception: ${e.javaClass.simpleName}: ${e.message}"

--- a/socialtools_app/app/src/main/res/layout/fragment_instagram_tools.xml
+++ b/socialtools_app/app/src/main/res/layout/fragment_instagram_tools.xml
@@ -181,6 +181,16 @@
             android:text="Start"
             android:layout_margin="16dp" />
 
+        <TextView
+            android:id="@+id/text_process_time"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:gravity="center_horizontal"
+            android:text="@string/process_time_placeholder"
+            android:paddingBottom="4dp" />
+
         <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="0dp"

--- a/socialtools_app/app/src/main/res/values/strings.xml
+++ b/socialtools_app/app/src/main/res/values/strings.xml
@@ -32,4 +32,6 @@
     <string name="generate_comment">Generate Comment</string>
     <string name="error_generating_comment">Failed to generate comment</string>
     <string name="check_ai_comment">Check AI Comment</string>
+    <string name="process_time_placeholder">Process time: -</string>
+    <string name="process_time_result">Process time: %1$d s</string>
 </resources>


### PR DESCRIPTION
## Summary
- display process duration on the Instagram tools screen
- include placeholder text for process time
- show raw API responses in the AI comment checker on failure

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b4a2073c8327b12cd38efe1443a5