### PR TITLE
Clarify .env location and build script lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ automation interface on launch.
 
 ## Configuration
 
-Create a `.env` file in the repository root containing any optional
-configuration values. For example:
+Create a `.env` file in the repository root **or** inside the
+`socialtools_app` directory containing any optional configuration values.
+For example:
 
 ```
 OPENAI_API_KEY=sk-...

--- a/socialtools_app/app/build.gradle.kts
+++ b/socialtools_app/app/build.gradle.kts
@@ -6,9 +6,16 @@ plugins {
 }
 
 val envProps = Properties().apply {
-    val envFile = rootProject.file(".env")
-    if (envFile.exists()) {
-        envFile.inputStream().use { load(it) }
+    // Attempt to load .env from the project directory or repository root
+    val possibleLocations = listOf(
+        rootProject.file(".env"),
+        rootProject.rootDir.parentFile.resolve(".env")
+    )
+    for (file in possibleLocations) {
+        if (file.exists()) {
+            file.inputStream().use { load(it) }
+            break
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- load `.env` from project or repository root during build
- explain either `.env` location in README

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_6867b922da88832782ba18c249a0df38