### PR TITLE
Add delay after Instagram uploads

### DIFF
--- a/docs/BUSINESS_PROCESS.md
+++ b/docs/BUSINESS_PROCESS.md
@@ -63,6 +63,7 @@ SocialToolsApp provides utilities for automating social media activity. The appl
 ## Background Automation Sequence
 
 The automation routine (implemented in `InstagramToolsFragment`) performs actions such as liking, reposting, and commenting in a loop over daily posts. Randomized delays are used between actions to avoid suspicious behavior. Likes wait between 3–12 seconds, while AI-generated comment actions pause for 30–120 seconds. Status updates are appended to the on‑screen log and saved in a per‑user log file.
+Uploads also pause briefly after the network request completes. A 3‑second delay ensures the media transcode on Instagram's servers finishes before the next action begins.
 
 ## Summary
 

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -932,6 +932,8 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                                 client.actions().timeline().uploadAlbum(infos, post.caption ?: "").join()
                             }
                         }
+                        // wait to ensure upload/transcode finishes before continuing
+                        delay(3000)
                         newLink = response.media?.code?.let { "https://instagram.com/p/$it" }
                     }
                     newLink?.let {
@@ -1095,9 +1097,9 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
     private suspend fun showWaitingDots(duration: Long) {
         var remaining = duration
         while (remaining > 0) {
-            delay(5000)
+            delay(3000)
             appendLog(".", animate = false)
-            remaining -= 5000
+            remaining -= 3000
         }
     }
 


### PR DESCRIPTION
## Summary
- add a 3 second wait after each upload call to avoid `transcode not finished` errors
- show waiting dots using 3-second intervals
- document the new upload delay in the business process docs

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867cefb60f48327a00753fa37842272