### PR TITLE
Add IG comment web fallback

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -674,9 +674,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                     }
                     try {
                         withContext(Dispatchers.IO) {
-                            client.sendRequest(
-                                com.github.instagram4j.instagram4j.requests.media.MediaCommentRequest(id, text)
-                            ).join()
+                            client.commentWithFallback(id, text)
                         }
                         withContext(Dispatchers.Main) { appendLog("> commented [$code]", animate = true) }
                         flareCommentedIds.add(code)
@@ -897,9 +895,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                     }
                     try {
                         withContext(Dispatchers.IO) {
-                            client.sendRequest(
-                                com.github.instagram4j.instagram4j.requests.media.MediaCommentRequest(id, text)
-                            ).join()
+                            client.commentWithFallback(id, text)
                         }
                         appendLog(
                             "> commented on [$code]",

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/AiCommentCheckActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/AiCommentCheckActivity.kt
@@ -21,7 +21,7 @@ import org.json.JSONObject
 import java.io.File
 import com.github.instagram4j.instagram4j.IGClient
 import com.github.instagram4j.instagram4j.requests.feed.FeedUserRequest
-import com.github.instagram4j.instagram4j.requests.media.MediaCommentRequest
+import com.cicero.socialtools.utils.commentWithFallback
 import java.util.concurrent.TimeUnit
 
 /** Simple screen to test AI comment generation using OpenAI. */
@@ -136,9 +136,7 @@ class AiCommentCheckActivity : AppCompatActivity() {
                     }
                     return@launch
                 }
-                client.sendRequest(
-                    MediaCommentRequest(item.id, commentText)
-                ).join()
+                client.commentWithFallback(item.id, commentText)
                 withContext(Dispatchers.Main) {
                     resultView.text = "Comment posted: $commentText"
                 }

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/utils/IgCommentUtils.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/utils/IgCommentUtils.kt
@@ -1,0 +1,41 @@
+package com.cicero.socialtools.utils
+
+import com.github.instagram4j.instagram4j.IGClient
+import com.github.instagram4j.instagram4j.requests.media.MediaCommentRequest
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.FormBody
+import okhttp3.Request
+import java.io.IOException
+
+/** Helper to post Instagram comments with a fallback using web requests. */
+suspend fun IGClient.commentWithFallback(mediaId: String, text: String) {
+    try {
+        withContext(Dispatchers.IO) {
+            sendRequest(MediaCommentRequest(mediaId, text)).join()
+        }
+    } catch (e: Exception) {
+        withContext(Dispatchers.IO) {
+            postWebComment(mediaId, text)
+        }
+    }
+}
+
+@Throws(IOException::class)
+fun IGClient.postWebComment(mediaId: String, text: String) {
+    val body = FormBody.Builder()
+        .add("comment_text", text)
+        .add("replied_to_comment_id", "")
+        .build()
+    val request = Request.Builder()
+        .url("https://www.instagram.com/web/comments/${mediaId}/add/")
+        .header("X-CSRFToken", csrfToken)
+        .header("Referer", "https://www.instagram.com")
+        .post(body)
+        .build()
+    httpClient.newCall(request).execute().use { resp ->
+        if (!resp.isSuccessful) {
+            throw IOException("HTTP ${'$'}{resp.code}")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add IgCommentUtils with `commentWithFallback`
- use `commentWithFallback` when commenting on posts or flare accounts
- update AI comment check to use the new helper

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_6867e178c1c48327b54c0e6e4935bd77