### PR TITLE
Fix Friendship following property access

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -594,7 +594,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
             val friendship = withContext(Dispatchers.IO) {
                 action.getFriendship().join()
             }
-            if (!friendship.following) {
+            if (!friendship.isFollowing) {
                 withContext(Dispatchers.IO) {
                     action.action(FriendshipsActionRequest.FriendshipsAction.CREATE).join()
                 }


### PR DESCRIPTION
## Summary
- fix access to the `Friendship` object by using `isFollowing`

## Testing
- `gradle test` *(fails: Starting a Gradle Daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6867e496ddf483278065043b3017b43d