### PR TITLE
Improve repost logging

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -984,6 +984,11 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                 }
                 if (files.isEmpty()) continue
                 try {
+                    val fileList = files.joinToString { it.name }
+                    appendLog("> uploading [${post.code}] $fileList", animate = true)
+                    post.caption?.takeIf { it.isNotBlank() }?.let {
+                        appendLog("> caption: $it", animate = true)
+                    }
                     var newLink: String? = null
                     withContext(Dispatchers.IO) {
                         Log.d("InstagramToolsFragment", "Uploading ${post.code}")
@@ -1003,6 +1008,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                         delay(uploadDelayMs)
                         newLink = response.media?.code?.let { "https://instagram.com/p/$it" }
                     }
+                    appendLog("> upload success [${post.code}]", animate = true)
                     newLink?.let {
                         Log.d("InstagramToolsFragment", "Send link $it")
                         appendLog("> repost link: $it", animate = true)


### PR DESCRIPTION
## Summary
- log file list and caption when uploading
- show success message in log after upload completes

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_6867ef6103dc8327ad255e5bad2e87c8