### PR TITLE
Fix missing import for InstagramWebSession

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -19,6 +19,7 @@ import com.bumptech.glide.Glide
 import com.cicero.socialtools.BuildConfig
 import com.cicero.socialtools.R
 import com.cicero.socialtools.utils.OpenAiUtils
+import com.cicero.socialtools.utils.InstagramWebSession
 import com.cicero.socialtools.utils.commentWithFallback
 import com.github.instagram4j.instagram4j.IGClient
 import com.github.instagram4j.instagram4j.IGClient.Builder.LoginHandler


### PR DESCRIPTION
## Summary
- add import for `InstagramWebSession` in `InstagramToolsFragment`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_6867f3793a608327b50dc827a6097b8c