### PR TITLE
Remove Instagram web login and use IG4J cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ skipped to avoid re-uploading identical content.
 
 ### Web Session Commenting
 
-If the standard Instagram4j session cookies are missing or invalid, the app can
-fall back to a lightweight web login managed by `InstagramWebSession`. The
-helper stores cookies in `SharedPreferences` and posts comments using the same
-headers as the desktop web client.
+Comments are still sent through the Instagram web endpoint, but the app now
+uses cookies from the logged-in Instagram4j session. The previous web login
+helper has been removed to avoid triggering account warnings.
 
 ## Configuration
 

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -297,7 +297,6 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                     twoFactorHandler,
                     challengeHandler
                 )
-                InstagramWebSession.login(requireContext(), user, pass)
                 client.serialize(clientFile, cookieFile)
                 val info = client.actions().users().info(client.selfProfile.pk).join()
                 withContext(Dispatchers.Main) {
@@ -710,7 +709,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                         }
                         try {
                             withContext(Dispatchers.IO) {
-                                client.commentWithFallback(requireContext(), id, code, text)
+                                client.commentWithFallback(id, code, text)
                             }
                             withContext(Dispatchers.Main) {
                                 appendLog("> commented [sc=$code, id=$id]", animate = true)
@@ -931,7 +930,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                     }
                     try {
                         withContext(Dispatchers.IO) {
-                            client.commentWithFallback(requireContext(), id, code, text)
+                            client.commentWithFallback(id, code, text)
                         }
                         appendLog(
                             "> commented on [sc=$code, id=$id]",

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/AiCommentCheckActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/AiCommentCheckActivity.kt
@@ -136,7 +136,7 @@ class AiCommentCheckActivity : AppCompatActivity() {
                     }
                     return@launch
                 }
-                client.commentWithFallback(this@AiCommentCheckActivity, item.id, item.code, commentText)
+                client.commentWithFallback(item.id, item.code, commentText)
                 withContext(Dispatchers.Main) {
                     resultView.text = "Comment posted: $commentText"
                 }

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/utils/IgCommentUtils.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/utils/IgCommentUtils.kt
@@ -1,6 +1,5 @@
 package com.cicero.socialtools.utils
 
-import android.content.Context
 import com.github.instagram4j.instagram4j.IGClient
 import com.github.instagram4j.instagram4j.requests.media.MediaCommentRequest
 import com.cicero.socialtools.utils.InstagramWebSession
@@ -12,7 +11,6 @@ import java.io.IOException
 
 /** Helper to post Instagram comments with a fallback using web requests. */
 suspend fun IGClient.commentWithFallback(
-    context: Context,
     mediaId: String,
     shortcode: String,
     text: String
@@ -34,7 +32,7 @@ suspend fun IGClient.commentWithFallback(
     }
     if (!success) {
         withContext(Dispatchers.IO) {
-            InstagramWebSession.postComment(context, mediaId, shortcode, text)
+            InstagramWebSession.postComment(this, mediaId, shortcode, text)
         }
     }
 }

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/utils/InstagramWebSession.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/utils/InstagramWebSession.kt
@@ -1,110 +1,36 @@
 package com.cicero.socialtools.utils
 
-import android.content.Context
-import okhttp3.FormBody
-import okhttp3.OkHttpClient
-import okhttp3.Request
+import com.github.instagram4j.instagram4j.IGClient
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.net.URLEncoder
 
 /**
- * Simple helper to manage a lightweight Instagram web session.
- * Cookies are persisted in SharedPreferences under the key "web_ig_cookies".
+ * Helper to post comments via the Instagram web endpoint using cookies from
+ * an existing Instagram4j session. The previous web login mechanism has been
+ * removed to avoid triggering Instagram warnings.
  */
 object InstagramWebSession {
-    private const val PREF_NAME = "web_ig_cookies"
-    private val cookieMap = mutableMapOf<String, String>()
-
-    private fun updateCookiesFromHeaders(headers: List<String>) {
-        for (c in headers) {
-            val pair = c.substringBefore(';').split('=', limit = 2)
-            if (pair.size == 2) {
-                cookieMap[pair[0]] = pair[1]
-            }
-        }
-    }
-
-    fun load(context: Context) {
-        cookieMap.clear()
-        val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
-        for ((k, v) in prefs.all) {
-            val value = v as? String ?: continue
-            cookieMap[k] = value
-        }
-    }
-
-    private fun save(context: Context) {
-        val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
-        prefs.edit().apply {
-            clear()
-            cookieMap.forEach { (k, v) -> putString(k, v) }
-            apply()
-        }
-    }
-
-    private fun cookieHeader(): String =
-        cookieMap.entries.joinToString("; ") { "${it.key}=${it.value}" }
-
-    fun isLoggedIn(): Boolean = cookieMap.containsKey("sessionid") && cookieMap.containsKey("csrftoken")
-
     /**
-     * Perform basic web login to Instagram and persist cookies if successful.
+     * Post a comment using cookies from the given [IGClient] session.
      */
-    fun login(context: Context, username: String, password: String): Boolean {
-        val client = OkHttpClient()
-        // initial request to obtain csrftoken
-        val initReq = Request.Builder()
-            .url("https://www.instagram.com/accounts/login/")
-            .header("User-Agent", "Mozilla/5.0")
-            .get()
-            .build()
-        client.newCall(initReq).execute().use { resp ->
-            updateCookiesFromHeaders(resp.headers("Set-Cookie"))
-        }
-        val csrf = cookieMap["csrftoken"] ?: return false
-        val body = FormBody.Builder()
-            .add("username", username)
-            .add("enc_password", password)
-            .add("queryParams", "{}")
-            .add("optIntoOneTap", "false")
-            .build()
-        val loginReq = Request.Builder()
-            .url("https://www.instagram.com/accounts/login/ajax/")
-            .header("User-Agent", "Mozilla/5.0")
-            .header("X-CSRFToken", csrf)
-            .header("X-Requested-With", "XMLHttpRequest")
-            .header("Referer", "https://www.instagram.com/accounts/login/")
-            .header("Cookie", cookieHeader())
-            .post(body)
-            .build()
-        val success = client.newCall(loginReq).execute().use { resp ->
-            updateCookiesFromHeaders(resp.headers("Set-Cookie"))
-            resp.isSuccessful && resp.body?.string()?.contains("\"authenticated\": true") == true
-        }
-        if (success) save(context) else cookieMap.clear()
-        return success
-    }
+    fun postComment(client: IGClient, mediaId: String, shortcode: String, text: String): Boolean {
+        val cookieJar = client.httpClient.cookieJar
+        val cookies = cookieJar.loadForRequest("https://www.instagram.com/".toHttpUrl())
+        val cookieHeader = cookies.joinToString("; ") { "${it.name}=${it.value}" }
 
-    /**
-     * Post a comment using the stored web session cookies.
-     */
-    fun postComment(context: Context, mediaId: String, shortcode: String, text: String): Boolean {
-        if (!isLoggedIn()) {
-            load(context)
-            if (!isLoggedIn()) return false
-        }
-        val client = OkHttpClient()
         val body = "comment_text=" + URLEncoder.encode(text, "UTF-8")
         val req = Request.Builder()
-            .url("https://www.instagram.com/web/comments/${'$'}mediaId/add/")
+            .url("https://www.instagram.com/web/comments/$mediaId/add/")
             .post(body.toRequestBody("application/x-www-form-urlencoded".toMediaType()))
             .addHeader("User-Agent", "Mozilla/5.0")
-            .addHeader("X-CSRFToken", cookieMap["csrftoken"] ?: "")
-            .addHeader("Cookie", cookieHeader())
-            .addHeader("Referer", "https://www.instagram.com/p/${'$'}shortcode/")
+            .addHeader("X-CSRFToken", client.csrfToken)
+            .addHeader("Cookie", cookieHeader)
+            .addHeader("Referer", "https://www.instagram.com/p/$shortcode/")
             .build()
-        return client.newCall(req).execute().use { it.isSuccessful }
+
+        return client.httpClient.newCall(req).execute().use { it.isSuccessful }
     }
 }
-


### PR DESCRIPTION
## Summary
- rely solely on instagram4j cookies for commenting
- remove the web session login mechanism
- update comment helpers and callers
- document new cookie behavior

## Testing
- `./gradlew test` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_6867f8b26354832798a70fcce042fa0c