### PR TITLE
Fix instagram4j variant resolution

### DIFF
--- a/socialtools_app/app/build.gradle.kts
+++ b/socialtools_app/app/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     implementation("androidx.fragment:fragment-ktx:1.6.2")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("com.github.bumptech.glide:glide:4.16.0")
-    implementation(project(":instagram4j"))
+    implementation("com.github.instagram4j:instagram4j:2.0.7")
 
     testImplementation(kotlin("test"))
     testImplementation("junit:junit:4.13.2")

--- a/socialtools_app/settings.gradle.kts
+++ b/socialtools_app/settings.gradle.kts
@@ -16,5 +16,3 @@ dependencyResolutionManagement {
 rootProject.name = "SocialToolsApp"
 
 include(":app")
-include(":instagram4j")
-project(":instagram4j").projectDir = File(rootDir, "external/instagram4j")


### PR DESCRIPTION
## Summary
- use the published instagram4j artifact instead of a local module
- remove the unused instagram4j project from Gradle settings

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68688e1c32ac8327b934badf71f519ad