### PR TITLE
Add restrictions to AI comment prompt

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/utils/OpenAiUtils.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/utils/OpenAiUtils.kt
@@ -21,7 +21,8 @@ object OpenAiUtils {
         val clean = sanitizeCaption(caption)
         val prompt =
             "Buat komentar Instagram yang ceria, bersahabat, dan mendukung. " +
-                "Maksimal 15 kata. Gunakan nada ringan dan tulus untuk caption berikut: " +
+                "Maksimal 15 kata. Tanpa hashtag, mention, atau emotikon. " +
+                "Gunakan nada ringan dan tulus untuk caption berikut: " +
                 clean
         val message = JSONObject().apply {
             put("role", "user")


### PR DESCRIPTION
## Summary
- refine `OpenAiUtils` prompt so generated comments omit hashtags, mentions, and emoticons

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686899bdea4c83279048fb4c66804a71