### PR TITLE
Implement Instagram auto-comment via AccessibilityService

### DIFF
--- a/docs/AI_COMMENT_TEST_SCENARIO.md
+++ b/docs/AI_COMMENT_TEST_SCENARIO.md
@@ -1,11 +1,115 @@
-# AI Comment Generation Check
+# Check AI Comment
 
-This page describes how to verify that comment generation via OpenAI works inside the app.
+Dokumen ini diganti untuk menampilkan contoh aplikasi Android sederhana yang
+memanfaatkan `AccessibilityService` guna mengisi kolom komentar pada aplikasi
+Instagram secara otomatis. Komentar diinput melalui `EditText` di `MainActivity`
+kemudian dikirim ke service agar dituliskan ke postingan yang sedang dibuka dan
+menekan tombol "Post".
 
-## Steps
-1. Launch the app and log in to Instagram as usual.
-2. Tap the menu icon and select **Check AI Comment**.
-3. In the test screen enter any caption text then tap **Generate Comment**.
-4. The app calls the OpenAI API and displays the generated comment or an error message.
+## Kode Kotlin
+```kotlin
+// MainActivity.kt
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
 
-If a comment is returned, the integration is working correctly.
+        val commentInput = findViewById<EditText>(R.id.input_comment)
+        findViewById<Button>(R.id.button_send_comment).setOnClickListener {
+            val intent = Intent(ACTION_INPUT_COMMENT).apply {
+                putExtra(EXTRA_COMMENT, commentInput.text.toString())
+            }
+            sendBroadcast(intent)
+        }
+    }
+}
+```
+
+```xml
+<!-- res/layout/activity_main.xml -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText
+        android:id="@+id/input_comment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Tulis komentar"/>
+
+    <Button
+        android:id="@+id/button_send_comment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Kirim"/>
+</LinearLayout>
+```
+
+```kotlin
+// InstagramCommentService.kt
+class InstagramCommentService : AccessibilityService() {
+    private var currentComment: String? = null
+    private val receiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action == ACTION_INPUT_COMMENT) {
+                currentComment = intent.getStringExtra(EXTRA_COMMENT)
+                fillComment()
+            }
+        }
+    }
+
+    override fun onServiceConnected() {
+        registerReceiver(receiver, IntentFilter(ACTION_INPUT_COMMENT))
+    }
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) {}
+
+    override fun onInterrupt() {}
+
+    private fun fillComment() {
+        val text = currentComment ?: return
+        val root = rootInActiveWindow ?: return
+        val input = root.findAccessibilityNodeInfosByViewId(
+            "com.instagram.android:id/layout_comment_thread_edittext"
+        ).firstOrNull() ?: return
+        val args = Bundle().apply {
+            putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, text)
+        }
+        input.performAction(AccessibilityNodeInfo.ACTION_FOCUS)
+        input.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args)
+        root.findAccessibilityNodeInfosByText("Post")
+            .firstOrNull()?.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+    }
+}
+```
+
+## Konfigurasi Service dan Permission
+Tambahkan entri berikut di `AndroidManifest.xml`:
+```xml
+<service
+    android:name=".InstagramCommentService"
+    android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+    android:exported="false">
+    <intent-filter>
+        <action android:name="android.accessibilityservice.AccessibilityService"/>
+    </intent-filter>
+    <meta-data
+        android:name="android.accessibilityservice"
+        android:resource="@xml/insta_service_config"/>
+</service>
+```
+
+`res/xml/insta_service_config.xml`:
+```xml
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowStateChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:packageNames="com.instagram.android"
+    android:description="@string/service_description"/>
+```
+
+Dengan konfigurasi di atas, ketika tombol pada `MainActivity` diklik, komentar
+yang diinput akan diisi pada kolom komentar postingan Instagram yang sedang
+terbuka lalu tombol "Post" ditekan secara otomatis.

--- a/socialtools_app/app/src/main/AndroidManifest.xml
+++ b/socialtools_app/app/src/main/AndroidManifest.xml
@@ -30,5 +30,16 @@
         <service
             android:name=".core.services.PostService"
             android:exported="false" />
+        <service
+            android:name=".core.services.InstagramCommentService"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/instagram_comment_service" />
+        </service>
     </application>
 </manifest>

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/InstagramCommentService.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/InstagramCommentService.kt
@@ -1,0 +1,59 @@
+package com.cicero.socialtools.core.services
+
+import android.accessibilityservice.AccessibilityService
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Bundle
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+import com.cicero.socialtools.ui.MainActivity
+
+/** Accessibility service that fills the comment field in Instagram and presses Post. */
+class InstagramCommentService : AccessibilityService() {
+    private var currentComment: String? = null
+
+    private val receiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action == MainActivity.ACTION_INPUT_COMMENT) {
+                currentComment = intent.getStringExtra(MainActivity.EXTRA_COMMENT)
+                fillComment()
+            }
+        }
+    }
+
+    override fun onServiceConnected() {
+        registerReceiver(receiver, IntentFilter(MainActivity.ACTION_INPUT_COMMENT))
+    }
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) {
+        // no-op
+    }
+
+    override fun onInterrupt() {}
+
+    override fun onDestroy() {
+        unregisterReceiver(receiver)
+        super.onDestroy()
+    }
+
+    private fun fillComment() {
+        val text = currentComment ?: return
+        val root = rootInActiveWindow ?: return
+        val input = root.findAccessibilityNodeInfosByViewId(
+            "com.instagram.android:id/layout_comment_thread_edittext"
+        ).firstOrNull() ?: return
+        val args = Bundle().apply {
+            putCharSequence(
+                AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE,
+                text
+            )
+        }
+        input.performAction(AccessibilityNodeInfo.ACTION_FOCUS)
+        input.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args)
+        root.findAccessibilityNodeInfosByText("Post")
+            .firstOrNull()?.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+        currentComment = null
+    }
+}

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/AiCommentCheckActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/AiCommentCheckActivity.kt
@@ -1,155 +1,20 @@
 package com.cicero.socialtools.ui
 
+import android.content.Intent
 import android.os.Bundle
-import android.util.Log
+import android.provider.Settings
 import android.widget.Button
-import android.widget.EditText
-import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-import com.cicero.socialtools.BuildConfig
 import com.cicero.socialtools.R
-import com.cicero.socialtools.utils.OpenAiUtils
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
-import org.json.JSONObject
-import java.io.File
-import com.github.instagram4j.instagram4j.IGClient
-import com.github.instagram4j.instagram4j.requests.feed.FeedUserRequest
-import com.cicero.socialtools.utils.commentWithFallback
-import java.util.concurrent.TimeUnit
 
-/** Simple screen to test AI comment generation using OpenAI. */
+/** Screen that links to accessibility settings so the user can enable the service. */
 class AiCommentCheckActivity : AppCompatActivity() {
-
-    private fun createHttpClient(): OkHttpClient =
-        OkHttpClient.Builder()
-            .connectTimeout(60, TimeUnit.SECONDS)
-            .readTimeout(120, TimeUnit.SECONDS)
-            .writeTimeout(60, TimeUnit.SECONDS)
-            .callTimeout(180, TimeUnit.SECONDS)
-            .build()
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_ai_comment_check)
 
-        val input = findViewById<EditText>(R.id.input_caption)
-        val result = findViewById<TextView>(R.id.text_result)
-        val button = findViewById<Button>(R.id.button_generate)
-        val commentButton = findViewById<Button>(R.id.button_comment_last_post)
-
-        button.setOnClickListener {
-            result.text = getString(R.string.loading)
-            val caption = input.text.toString()
-            CoroutineScope(Dispatchers.IO).launch {
-                val responseText = fetchAiComment(caption)
-                withContext(Dispatchers.Main) {
-                    result.text = responseText
-                }
-            }
+        findViewById<Button>(R.id.button_open_settings).setOnClickListener {
+            startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
         }
-
-        commentButton.setOnClickListener {
-            result.text = getString(R.string.loading)
-            commentLatestPost(result)
-        }
-    }
-
-    private fun fetchAiComment(caption: String): String {
-        val apiKey = BuildConfig.OPENAI_API_KEY.ifBlank {
-            System.getenv("OPENAI_API_KEY") ?: ""
-        }
-        if (apiKey.isBlank()) {
-            return "API key missing"
-        }
-        if (caption.isBlank()) {
-            return "Caption empty"
-        }
-
-        val json = OpenAiUtils.buildRequestJson(caption)
-        val client = createHttpClient()
-        val req = Request.Builder()
-            .url("https://api.openai.com/v1/chat/completions")
-            .header("Authorization", "Bearer $apiKey")
-            .header("Content-Type", "application/json")
-            .post(json.toRequestBody("application/json; charset=utf-8".toMediaType()))
-            .build()
-        return try {
-            client.newCall(req).execute().use { resp ->
-                val bodyStr = resp.body?.string()
-                if (!resp.isSuccessful) {
-                    Log.d("AiCommentCheck", "Error ${resp.code} response: ${bodyStr}")
-                    return "Error ${resp.code}: ${bodyStr}".trim()
-                }
-                Log.d("AiCommentCheck", "Raw response: $bodyStr")
-                val obj = JSONObject(bodyStr ?: "{}")
-                val text = obj.getJSONArray("choices")
-                    .optJSONObject(0)
-                    ?.optJSONObject("message")
-                    ?.optString("content")
-                    ?.trim()
-                if (text.isNullOrBlank()) {
-                    return "Raw response: ${bodyStr?.take(200)}"
-                }
-                limitWords(text, 15)
-            }
-        } catch (e: Exception) {
-            "Exception: ${e.javaClass.simpleName}: ${e.message}"
-        }
-    }
-
-    private fun commentLatestPost(resultView: TextView) {
-        CoroutineScope(Dispatchers.IO).launch {
-            val clientFile = File(filesDir, "igclient.ser")
-            val cookieFile = File(filesDir, "igcookie.ser")
-            if (!clientFile.exists() || !cookieFile.exists()) {
-                withContext(Dispatchers.Main) {
-                    resultView.text = "Instagram session not found"
-                }
-                return@launch
-            }
-            try {
-                val client = IGClient.deserialize(clientFile, cookieFile)
-                val userAction = client.actions().users()
-                    .findByUsername("polresbojonegoroofficial").join()
-                val feed = client.sendRequest(
-                    FeedUserRequest(userAction.user.pk)
-                ).join()
-                val item = feed.items.firstOrNull()
-                if (item == null) {
-                    withContext(Dispatchers.Main) {
-                        resultView.text = "No posts found"
-                    }
-                    return@launch
-                }
-                val captionText = item.caption?.text ?: ""
-                val commentText = fetchAiComment(captionText)
-                if (commentText.isBlank()) {
-                    withContext(Dispatchers.Main) {
-                        resultView.text = getString(R.string.error_generating_comment)
-                    }
-                    return@launch
-                }
-                client.commentWithFallback(item.id, item.code, commentText)
-                withContext(Dispatchers.Main) {
-                    resultView.text = "Comment posted: $commentText"
-                }
-            } catch (e: Exception) {
-                withContext(Dispatchers.Main) {
-                    resultView.text = "Error: ${e.message}"
-                }
-            }
-        }
-    }
-
-    private fun limitWords(text: String, maxWords: Int): String {
-        val words = text.split(Regex("\\s+")).filter { it.isNotBlank() }
-        return words.take(maxWords).joinToString(" ").trim()
     }
 }

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/MainActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/MainActivity.kt
@@ -2,13 +2,21 @@ package com.cicero.socialtools.ui
 
 import android.os.Bundle
 import android.content.Intent
+import android.content.IntentFilter
 import android.os.Build
+import android.widget.Button
+import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import com.cicero.socialtools.R
 import com.cicero.socialtools.features.instagram.InstagramToolsFragment
 import com.cicero.socialtools.core.services.PostService
 
 class MainActivity : AppCompatActivity() {
+    companion object {
+        const val ACTION_INPUT_COMMENT = "com.cicero.socialtools.INPUT_COMMENT"
+        const val EXTRA_COMMENT = "extra_comment"
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         startPostService()
@@ -18,6 +26,15 @@ class MainActivity : AppCompatActivity() {
             supportFragmentManager.beginTransaction()
                 .replace(R.id.fragment_container, InstagramToolsFragment())
                 .commit()
+        }
+
+        val input = findViewById<EditText>(R.id.input_comment)
+        val button = findViewById<Button>(R.id.button_send_comment)
+        button.setOnClickListener {
+            val intent = Intent(ACTION_INPUT_COMMENT).apply {
+                putExtra(EXTRA_COMMENT, input.text.toString())
+            }
+            sendBroadcast(intent)
         }
     }
 

--- a/socialtools_app/app/src/main/res/layout/activity_ai_comment_check.xml
+++ b/socialtools_app/app/src/main/res/layout/activity_ai_comment_check.xml
@@ -1,41 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:padding="16dp"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="Caption">
-
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/input_caption"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-    </com.google.android.material.textfield.TextInputLayout>
-
-    <Button
-        android:id="@+id/button_generate"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:text="@string/generate_comment" />
-
-    <Button
-        android:id="@+id/button_comment_last_post"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:text="@string/comment_last_post" />
-
     <TextView
-        android:id="@+id/text_result"
+        android:id="@+id/text_info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Enable the accessibility service to allow automatic comments." />
+
+    <Button
+        android:id="@+id/button_open_settings"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:textColor="@android:color/black" />
-
+        android:text="Open Accessibility Settings" />
 </LinearLayout>

--- a/socialtools_app/app/src/main/res/layout/activity_main.xml
+++ b/socialtools_app/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/fragment_container"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <EditText
+        android:id="@+id/input_comment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Masukkan komentar" />
+
+    <Button
+        android:id="@+id/button_send_comment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Kirim komentar" />
+</LinearLayout>

--- a/socialtools_app/app/src/main/res/values/strings.xml
+++ b/socialtools_app/app/src/main/res/values/strings.xml
@@ -35,4 +35,5 @@
     <string name="comment_last_post">Comment Latest Post</string>
     <string name="process_time_placeholder">Process time: -</string>
     <string name="process_time_result">Process time: %1$d s</string>
+    <string name="service_description">Instagram auto comment service</string>
 </resources>

--- a/socialtools_app/app/src/main/res/xml/instagram_comment_service.xml
+++ b/socialtools_app/app/src/main/res/xml/instagram_comment_service.xml
@@ -1,0 +1,5 @@
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowStateChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:packageNames="com.instagram.android"
+    android:description="@string/service_description" />


### PR DESCRIPTION
## Summary
- overhaul the Check AI Comment page with a new example
- enable comment input from `MainActivity`
- implement `InstagramCommentService` AccessibilityService
- register the service in `AndroidManifest.xml`
- update layouts and strings

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_6868d4a328a48327a2647d70ca898766