### PR TITLE
Enable manual comment on IG tools page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Ignore environment variables file
 .env
+socialtools_app/.gradle/
+socialtools_app/build/
+socialtools_app/app/build/

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
 import com.cicero.socialtools.BuildConfig
 import com.cicero.socialtools.R
+import com.cicero.socialtools.ui.MainActivity
 import com.cicero.socialtools.utils.OpenAiUtils
 import com.cicero.socialtools.utils.commentWithFallback
 import com.github.instagram4j.instagram4j.IGClient
@@ -198,11 +199,21 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
         likeCheckbox = view.findViewById(R.id.checkbox_like)
         repostCheckbox = view.findViewById(R.id.checkbox_repost)
         commentCheckbox = view.findViewById(R.id.checkbox_comment)
+        val commentInput = view.findViewById<EditText>(R.id.input_comment)
+        val commentButton = view.findViewById<Button>(R.id.button_send_comment)
         badgeView = profileView.findViewById(R.id.image_badge)
         logContainer = view.findViewById(R.id.log_container)
         logScroll = view.findViewById(R.id.log_scroll)
         clearLogsButton = view.findViewById(R.id.button_clear_logs)
         processTimeView = view.findViewById(R.id.text_process_time)
+
+        commentButton.setOnClickListener {
+            val text = commentInput.text.toString()
+            val intent = Intent(MainActivity.ACTION_INPUT_COMMENT).apply {
+                putExtra(MainActivity.EXTRA_COMMENT, text)
+            }
+            requireContext().sendBroadcast(intent)
+        }
 
         clearLogsButton.setOnClickListener { clearLogs() }
 

--- a/socialtools_app/app/src/main/res/layout/fragment_instagram_tools.xml
+++ b/socialtools_app/app/src/main/res/layout/fragment_instagram_tools.xml
@@ -168,11 +168,28 @@
             android:layout_marginTop="8dp"
             android:hint="Link Target">
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/input_target_link"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/input_target_link"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
         </com.google.android.material.textfield.TextInputLayout>
+
+        <EditText
+            android:id="@+id/input_comment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:hint="Masukkan komentar" />
+
+        <Button
+            android:id="@+id/button_send_comment"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginTop="8dp"
+            android:text="@string/send_comment" />
 
         <Button
             android:id="@+id/button_start"

--- a/socialtools_app/app/src/main/res/values/strings.xml
+++ b/socialtools_app/app/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="error_generating_comment">Failed to generate comment</string>
     <string name="check_ai_comment">Check AI Comment</string>
     <string name="comment_last_post">Comment Latest Post</string>
+    <string name="send_comment">Kirim komentar</string>
     <string name="process_time_placeholder">Process time: -</string>
     <string name="process_time_result">Process time: %1$d s</string>
     <string name="service_description">Instagram auto comment service</string>


### PR DESCRIPTION
## Summary
- add comment input and send button on Instagram Tools screen
- broadcast comment text when comment button is pressed
- update strings and ignore Gradle build artifacts

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869103620cc83278eedfd8ab71c0f70