### PR TITLE
Remove comment input UI

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -199,21 +199,12 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
         likeCheckbox = view.findViewById(R.id.checkbox_like)
         repostCheckbox = view.findViewById(R.id.checkbox_repost)
         commentCheckbox = view.findViewById(R.id.checkbox_comment)
-        val commentInput = view.findViewById<EditText>(R.id.input_comment)
-        val commentButton = view.findViewById<Button>(R.id.button_send_comment)
         badgeView = profileView.findViewById(R.id.image_badge)
         logContainer = view.findViewById(R.id.log_container)
         logScroll = view.findViewById(R.id.log_scroll)
         clearLogsButton = view.findViewById(R.id.button_clear_logs)
         processTimeView = view.findViewById(R.id.text_process_time)
 
-        commentButton.setOnClickListener {
-            val text = commentInput.text.toString()
-            val intent = Intent(MainActivity.ACTION_INPUT_COMMENT).apply {
-                putExtra(MainActivity.EXTRA_COMMENT, text)
-            }
-            requireContext().sendBroadcast(intent)
-        }
 
         clearLogsButton.setOnClickListener { clearLogs() }
 

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/MainActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/MainActivity.kt
@@ -2,10 +2,7 @@ package com.cicero.socialtools.ui
 
 import android.os.Bundle
 import android.content.Intent
-import android.content.IntentFilter
 import android.os.Build
-import android.widget.Button
-import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import com.cicero.socialtools.R
 import com.cicero.socialtools.features.instagram.InstagramToolsFragment
@@ -28,14 +25,6 @@ class MainActivity : AppCompatActivity() {
                 .commit()
         }
 
-        val input = findViewById<EditText>(R.id.input_comment)
-        val button = findViewById<Button>(R.id.button_send_comment)
-        button.setOnClickListener {
-            val intent = Intent(ACTION_INPUT_COMMENT).apply {
-                putExtra(EXTRA_COMMENT, input.text.toString())
-            }
-            sendBroadcast(intent)
-        }
     }
 
     private fun startPostService() {

--- a/socialtools_app/app/src/main/res/layout/activity_main.xml
+++ b/socialtools_app/app/src/main/res/layout/activity_main.xml
@@ -10,15 +10,4 @@
         android:layout_height="0dp"
         android:layout_weight="1" />
 
-    <EditText
-        android:id="@+id/input_comment"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="Masukkan komentar" />
-
-    <Button
-        android:id="@+id/button_send_comment"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Kirim komentar" />
 </LinearLayout>

--- a/socialtools_app/app/src/main/res/layout/fragment_instagram_tools.xml
+++ b/socialtools_app/app/src/main/res/layout/fragment_instagram_tools.xml
@@ -174,22 +174,6 @@
             android:layout_height="wrap_content" />
         </com.google.android.material.textfield.TextInputLayout>
 
-        <EditText
-            android:id="@+id/input_comment"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
-            android:hint="Masukkan komentar" />
-
-        <Button
-            android:id="@+id/button_send_comment"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginTop="8dp"
-            android:text="@string/send_comment" />
 
         <Button
             android:id="@+id/button_start"


### PR DESCRIPTION
## Summary
- strip comment input field and send button from `activity_main`
- remove comment UI elements from the instagram tools fragment
- drop related broadcast logic in `MainActivity` and `InstagramToolsFragment`

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_6869141a4fa483278ff387fec3d9e9f1