### PR TITLE
Use Chrome for web comments

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/InstagramCommentService.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/InstagramCommentService.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import com.cicero.socialtools.ui.MainActivity
+import java.util.ArrayDeque
 
 /** Accessibility service that fills the comment field in Instagram and presses Post. */
 class InstagramCommentService : AccessibilityService() {
@@ -41,20 +42,27 @@ class InstagramCommentService : AccessibilityService() {
     private fun fillComment() {
         val text = currentComment ?: return
         var root = rootInActiveWindow ?: return
-        var input = root.findAccessibilityNodeInfosByViewId(
-            "com.instagram.android:id/layout_comment_thread_edittext"
-        ).firstOrNull()
-
-        if (input == null) {
-            // Try opening the comment composer first
-            root.findAccessibilityNodeInfosByText("Comment")
-                .firstOrNull()?.performAction(AccessibilityNodeInfo.ACTION_CLICK)
-            // Allow the UI to update
-            Thread.sleep(500)
-            root = rootInActiveWindow ?: return
+        val packageName = root.packageName?.toString()
+        var input: AccessibilityNodeInfo? = null
+        if (packageName == "com.instagram.android") {
             input = root.findAccessibilityNodeInfosByViewId(
                 "com.instagram.android:id/layout_comment_thread_edittext"
             ).firstOrNull()
+
+            if (input == null) {
+                // Try opening the comment composer first
+                root.findAccessibilityNodeInfosByText("Comment")
+                    .firstOrNull()?.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+                // Allow the UI to update
+                Thread.sleep(500)
+                root = rootInActiveWindow ?: return
+                input = root.findAccessibilityNodeInfosByViewId(
+                    "com.instagram.android:id/layout_comment_thread_edittext"
+                ).firstOrNull()
+            }
+        } else {
+            // Running inside Chrome. Try to locate the comment box by heuristics.
+            input = findChromeInput(root)
         }
 
         if (input == null) return
@@ -67,8 +75,42 @@ class InstagramCommentService : AccessibilityService() {
         }
         input.performAction(AccessibilityNodeInfo.ACTION_FOCUS)
         input.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, args)
-        root.findAccessibilityNodeInfosByText("Post")
-            .firstOrNull()?.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+        findNodeByText(root, "Post")?.performAction(AccessibilityNodeInfo.ACTION_CLICK)
         currentComment = null
+    }
+
+    private fun findChromeInput(root: AccessibilityNodeInfo): AccessibilityNodeInfo? {
+        val queue: ArrayDeque<AccessibilityNodeInfo> = ArrayDeque()
+        queue.add(root)
+        while (queue.isNotEmpty()) {
+            val node = queue.removeFirst()
+            val className = node.className?.toString()
+            val text = node.text?.toString() ?: ""
+            val desc = node.contentDescription?.toString() ?: ""
+            if (className == "android.widget.EditText" &&
+                (text.contains("comment", true) || desc.contains("comment", true))) {
+                return node
+            }
+            for (i in 0 until node.childCount) {
+                node.getChild(i)?.let { queue.add(it) }
+            }
+        }
+        return null
+    }
+
+    private fun findNodeByText(root: AccessibilityNodeInfo, target: String): AccessibilityNodeInfo? {
+        val queue: ArrayDeque<AccessibilityNodeInfo> = ArrayDeque()
+        queue.add(root)
+        while (queue.isNotEmpty()) {
+            val node = queue.removeFirst()
+            val text = node.text?.toString() ?: ""
+            if (text.equals(target, true)) {
+                return node
+            }
+            for (i in 0 until node.childCount) {
+                node.getChild(i)?.let { queue.add(it) }
+            }
+        }
+        return null
     }
 }

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -1220,35 +1220,21 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
         val uri = Uri.parse("https://www.instagram.com/p/$shortcode/")
         val context = requireContext()
         val pm = context.packageManager
-        val appIntent = Intent(Intent.ACTION_VIEW, uri).apply {
-            setPackage("com.instagram.android")
+        val chromeIntent = Intent(Intent.ACTION_VIEW, uri).apply {
+            setPackage("com.android.chrome")
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
-        val canUseApp = appIntent.resolveActivity(pm) != null
         withContext(Dispatchers.Main) {
-            if (canUseApp) {
-                startActivity(appIntent)
-            } else {
-                startActivity(Intent(Intent.ACTION_VIEW, uri).apply {
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                })
-                Toast.makeText(
-                    context,
-                    "Instagram app not found, opening in browser",
-                    Toast.LENGTH_SHORT
-                ).show()
-            }
+            startActivity(chromeIntent)
         }
-        if (canUseApp) {
-            delay(3000)
-            val intent = Intent(MainActivity.ACTION_INPUT_COMMENT).apply {
-                putExtra(MainActivity.EXTRA_COMMENT, text)
-            }
-            context.sendBroadcast(intent)
-            delay(2000)
-            val back = pm.getLaunchIntentForPackage(context.packageName)
-            back?.let { withContext(Dispatchers.Main) { startActivity(it) } }
+        delay(3000)
+        val intent = Intent(MainActivity.ACTION_INPUT_COMMENT).apply {
+            putExtra(MainActivity.EXTRA_COMMENT, text)
         }
+        context.sendBroadcast(intent)
+        delay(2000)
+        val back = pm.getLaunchIntentForPackage(context.packageName)
+        back?.let { withContext(Dispatchers.Main) { startActivity(it) } }
     }
 
 

--- a/socialtools_app/app/src/main/res/xml/instagram_comment_service.xml
+++ b/socialtools_app/app/src/main/res/xml/instagram_comment_service.xml
@@ -1,5 +1,5 @@
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:accessibilityEventTypes="typeWindowStateChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
-    android:packageNames="com.instagram.android"
+    android:packageNames="com.instagram.android,com.android.chrome"
     android:description="@string/service_description" />


### PR DESCRIPTION
## Summary
- force comments to open in Chrome and send broadcast regardless of IG app presence
- expand `InstagramCommentService` to handle Chrome's web UI
- update service configuration to listen to Chrome windows

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68692899e2d483279badba1ade3e8c87