### PR TITLE
Ensure comment success detection

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/InstagramCommentService.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/InstagramCommentService.kt
@@ -28,6 +28,13 @@ class InstagramCommentService : AccessibilityService() {
         Log.d(TAG, message)
     }
 
+    private fun sendResult(success: Boolean) {
+        val intent = Intent(MainActivity.ACTION_COMMENT_RESULT).apply {
+            putExtra(MainActivity.EXTRA_COMMENT_SUCCESS, success)
+        }
+        sendBroadcast(intent)
+    }
+
     private fun logTree(node: AccessibilityNodeInfo?, indent: String = "") {
         if (!BuildConfig.DEBUG) return
         if (node == null) {
@@ -90,6 +97,7 @@ class InstagramCommentService : AccessibilityService() {
             if (BuildConfig.DEBUG) logTree(root)
             if (root == null) {
                 sendLog("Root window is null")
+                sendResult(false)
                 return@Thread
             }
 
@@ -111,6 +119,11 @@ class InstagramCommentService : AccessibilityService() {
                 if (BuildConfig.DEBUG) logTree(root)
                 input = findFirstEditText(root)
             }
+            if (input == null) {
+                sendLog("Comment input not found")
+                sendResult(false)
+                return@Thread
+            }
 
             val args = Bundle().apply {
                 putCharSequence(
@@ -127,6 +140,7 @@ class InstagramCommentService : AccessibilityService() {
                     it.performAction(AccessibilityNodeInfo.ACTION_CLICK)
                 }
             sendLog("Comment workflow complete")
+            sendResult(true)
         }.start()
     }
 }

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/MainActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/MainActivity.kt
@@ -14,6 +14,8 @@ class MainActivity : AppCompatActivity() {
         const val EXTRA_COMMENT = "extra_comment"
         const val ACTION_ACCESSIBILITY_LOG = "com.cicero.socialtools.ACCESS_LOG"
         const val EXTRA_LOG_MESSAGE = "extra_log"
+        const val ACTION_COMMENT_RESULT = "com.cicero.socialtools.COMMENT_RESULT"
+        const val EXTRA_COMMENT_SUCCESS = "extra_success"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
## Summary
- broadcast comment result success/failure from `InstagramCommentService`
- wait for comment result in `commentPostNative`
- stop comment loops if a comment fails
- expose new constants for comment results

## Testing
- `./socialtools_app/gradlew -p socialtools_app test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869427d889083278db08dcabbe29fd7