### PR TITLE
Improve tag collection error handling

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -174,7 +174,10 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                     media.user?.username?.let { if (it != targetUsername) flareTargets.add(it) }
                 }
             } catch (e: Exception) {
-                withContext(Dispatchers.Main) { appendLog("Error tag #$tag: ${e.message}") }
+                val msg = if (e.message?.contains("Unexpected character") == true) {
+                    "invalid response - check login"
+                } else e.message
+                withContext(Dispatchers.Main) { appendLog("Error tag #$tag: ${msg ?: "unknown"}") }
             }
         }
         withContext(Dispatchers.Main) { appendLog("> collected ${flareTargets.size} flare users", animate = true) }


### PR DESCRIPTION
## Summary
- tweak collectFlareTargets to handle invalid HTML responses

## Testing
- `./gradlew assembleDebug` *(fails: unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68694b3a01e88327bceb4cc8a061c29c