### PR TITLE
Add accessibility service check

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -20,7 +20,10 @@ import com.bumptech.glide.Glide
 import com.cicero.socialtools.BuildConfig
 import com.cicero.socialtools.R
 import com.cicero.socialtools.ui.MainActivity
+import com.cicero.socialtools.ui.AiCommentCheckActivity
 import com.cicero.socialtools.utils.OpenAiUtils
+import com.cicero.socialtools.utils.AccessibilityUtils
+import com.cicero.socialtools.core.services.InstagramCommentService
 import com.github.instagram4j.instagram4j.IGClient
 import com.github.instagram4j.instagram4j.IGClient.Builder.LoginHandler
 import com.github.instagram4j.instagram4j.actions.timeline.TimelineAction
@@ -1258,6 +1261,12 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
     private suspend fun commentPostNative(shortcode: String, text: String): Boolean {
         val uri = Uri.parse("https://www.instagram.com/p/$shortcode/")
         val context = requireContext()
+        if (!AccessibilityUtils.isServiceEnabled(context, InstagramCommentService::class.java)) {
+            withContext(Dispatchers.Main) {
+                startActivity(Intent(context, AiCommentCheckActivity::class.java))
+            }
+            return false
+        }
         val pm = context.packageManager
         val appIntent = Intent(Intent.ACTION_VIEW, uri).apply {
             setPackage("com.instagram.android")

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/AiCommentCheckActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/AiCommentCheckActivity.kt
@@ -4,6 +4,8 @@ import android.content.Intent
 import android.os.Bundle
 import android.provider.Settings
 import android.widget.Button
+import com.cicero.socialtools.core.services.InstagramCommentService
+import com.cicero.socialtools.utils.AccessibilityUtils
 import androidx.appcompat.app.AppCompatActivity
 import com.cicero.socialtools.R
 
@@ -15,6 +17,15 @@ class AiCommentCheckActivity : AppCompatActivity() {
 
         findViewById<Button>(R.id.button_open_settings).setOnClickListener {
             startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (!AccessibilityUtils.isServiceEnabled(this, InstagramCommentService::class.java)) {
+            startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+        } else {
+            finish()
         }
     }
 }

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/utils/AccessibilityUtils.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/utils/AccessibilityUtils.kt
@@ -1,0 +1,24 @@
+package com.cicero.socialtools.utils
+
+import android.accessibilityservice.AccessibilityService
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.content.Context
+import android.view.accessibility.AccessibilityManager
+
+/** Utility for checking accessibility service status. */
+object AccessibilityUtils {
+    /**
+     * Return true if the given accessibility service is enabled.
+     */
+    fun isServiceEnabled(context: Context, serviceClass: Class<out AccessibilityService>): Boolean {
+        val am = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+        val enabled = am.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK)
+        for (service in enabled) {
+            val info = service.resolveInfo.serviceInfo
+            if (info.packageName == context.packageName && info.name == serviceClass.name) {
+                return true
+            }
+        }
+        return false
+    }
+}


### PR DESCRIPTION
## Summary
- add `AccessibilityUtils` helper to detect if accessibility service is active
- update `AiCommentCheckActivity` to automatically open settings when service is disabled
- check accessibility in `InstagramToolsFragment` before commenting and launch settings if disabled

## Testing
- `./gradlew test` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_6869e140736c8327b625febee1bcce30