### PR TITLE
Improve comment failure logs

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/InstagramCommentService.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/InstagramCommentService.kt
@@ -28,9 +28,10 @@ class InstagramCommentService : AccessibilityService() {
         Log.d(TAG, message)
     }
 
-    private fun sendResult(success: Boolean) {
+    private fun sendResult(success: Boolean, error: String? = null) {
         val intent = Intent(MainActivity.ACTION_COMMENT_RESULT).apply {
             putExtra(MainActivity.EXTRA_COMMENT_SUCCESS, success)
+            putExtra(MainActivity.EXTRA_COMMENT_ERROR, error)
         }
         sendBroadcast(intent)
     }
@@ -107,8 +108,9 @@ class InstagramCommentService : AccessibilityService() {
             var root = rootInActiveWindow
             if (BuildConfig.DEBUG) logTree(root)
             if (root == null) {
-                sendLog("Root window is null")
-                sendResult(false)
+                val msg = "Root window is null"
+                sendLog(msg)
+                sendResult(false, msg)
                 return@Thread
             }
 
@@ -136,8 +138,9 @@ class InstagramCommentService : AccessibilityService() {
                 ).firstOrNull() ?: findFirstEditText(root)
             }
             if (input == null) {
-                sendLog("Comment input not found")
-                sendResult(false)
+                val msg = "Comment input not found"
+                sendLog(msg)
+                sendResult(false, msg)
                 return@Thread
             }
 

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/MainActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/MainActivity.kt
@@ -16,6 +16,7 @@ class MainActivity : AppCompatActivity() {
         const val EXTRA_LOG_MESSAGE = "extra_log"
         const val ACTION_COMMENT_RESULT = "com.cicero.socialtools.COMMENT_RESULT"
         const val EXTRA_COMMENT_SUCCESS = "extra_success"
+        const val EXTRA_COMMENT_ERROR = "extra_error"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
## Summary
- add `EXTRA_COMMENT_ERROR` constant
- include error text with comment result broadcasts
- return error details from `commentPostNative`
- show the specific failure reason when commenting fails

## Testing
- `gradle assembleDebug --stacktrace` *(fails: Task 'assembleDebug' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869edd1830c8327a763a0c43689698a