### PR TITLE
Fix root window null issue

### DIFF
--- a/docs/AI_COMMENT_TEST_SCENARIO.md
+++ b/docs/AI_COMMENT_TEST_SCENARIO.md
@@ -92,3 +92,11 @@ Tambahkan entri berikut di `AndroidManifest.xml`:
 Dengan konfigurasi di atas, ketika broadcast berisi komentar dikirim,
 `InstagramCommentService` akan mengisi kolom komentar pada postingan yang
 sedang terbuka dan menekan tombol "Post" secara otomatis.
+
+### Troubleshooting
+
+Jika log menampilkan pesan **"Root window is null"**, pastikan tampilan
+Instagram yang berisi kolom komentar sudah terbuka sepenuhnya. Accessibility
+Service membutuhkan jendela aktif yang valid agar bisa menemukan input
+komentar. Coba tunggu beberapa detik setelah membuka postingan atau tekan
+tombol komentar secara manual sebelum mengirim broadcast.

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/InstagramCommentService.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/InstagramCommentService.kt
@@ -105,7 +105,13 @@ class InstagramCommentService : AccessibilityService() {
             sendLog("Starting comment workflow")
             // wait to ensure post is fully opened
             Thread.sleep(2500)
-            var root = rootInActiveWindow
+            var root: AccessibilityNodeInfo? = null
+            // Retry a few times to allow the Instagram window to fully load
+            repeat(10) {
+                root = rootInActiveWindow
+                if (root != null) return@repeat
+                Thread.sleep(500)
+            }
             if (BuildConfig.DEBUG) logTree(root)
             if (root == null) {
                 val msg = "Root window is null"


### PR DESCRIPTION
## Summary
- retry retrieving the active root window for Instagram comment service
- document workaround when `Root window is null` occurs

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_6869f189b4708327a48be84c9417c881