### PR TITLE
Improve Instagram comment service

### DIFF
--- a/socialtools_app/app/src/main/res/xml/instagram_comment_service.xml
+++ b/socialtools_app/app/src/main/res/xml/instagram_comment_service.xml
@@ -1,5 +1,5 @@
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
-    android:accessibilityEventTypes="typeWindowStateChanged"
+    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
     android:packageNames="com.instagram.android"
     android:description="@string/service_description" />


### PR DESCRIPTION
## Summary
- enhance `InstagramCommentService` to wait for Instagram UI
- handle events only from Instagram
- add helper to print all nodes for debugging
- listen for more accessibility event types

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869f703086c8327b945f5d9365f24de