### PR TITLE
Improve Instagram comment service retry logic

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/InstagramCommentService.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/InstagramCommentService.kt
@@ -148,12 +148,18 @@ class InstagramCommentService : AccessibilityService() {
             sendLog("Starting comment workflow")
             // wait to ensure post is fully opened
             Thread.sleep(ACCESS_DELAY_MS)
-            var root = waitForRoot()
+            var root = rootInActiveWindow
+            if (root == null) {
+                sendLog("Root window masih null, menunggu 5 detik dan mencoba lagi")
+                Thread.sleep(5000)
+                root = rootInActiveWindow
+            }
             if (BuildConfig.DEBUG) logTree(root)
             val rootNode = root ?: run {
                 val msg = "Instagram UI not ready"
                 sendLog(msg)
                 sendResult(false, msg)
+                performGlobalAction(GLOBAL_ACTION_BACK)
                 return@Thread
             }
 

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -1291,7 +1291,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
         }
         if (!canUseApp) return false to "instagram app missing"
 
-        delay(3000)
+        delay(10000)
 
         val result = withTimeoutOrNull(15000) {
             suspendCancellableCoroutine<Pair<Boolean, String?>> { cont ->


### PR DESCRIPTION
## Summary
- add a retry delay when root window is null in `InstagramCommentService`
- wait longer after launching Instagram before injecting the comment

## Testing
- `./gradlew --version` *(fails: Invalid or corrupt jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_686a2ff52c308327b48b1febf0a947db