### PR TITLE
Improve comment accessibility polling

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/InstagramCommentService.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/InstagramCommentService.kt
@@ -148,12 +148,7 @@ class InstagramCommentService : AccessibilityService() {
             sendLog("Starting comment workflow")
             // wait to ensure post is fully opened
             Thread.sleep(ACCESS_DELAY_MS)
-            var root = rootInActiveWindow
-            if (root == null) {
-                sendLog("Root window masih null, menunggu 5 detik dan mencoba lagi")
-                Thread.sleep(5000)
-                root = rootInActiveWindow
-            }
+            var root = waitForRoot(10)
             if (BuildConfig.DEBUG) logTree(root)
             val rootNode = root ?: run {
                 val msg = "Instagram UI not ready"


### PR DESCRIPTION
## Summary
- rely on waitForRoot when commenting to avoid "Instagram UI not ready" errors

## Testing
- `gradle test` *(fails: could not access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686a32cfb76883278b3835b352e0bf1b