### PR TITLE
Fix comment timeout issue

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -1293,7 +1293,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
 
         delay(10000)
 
-        val result = withTimeoutOrNull(15000) {
+        val result = withTimeoutOrNull(60000) {
             suspendCancellableCoroutine<Pair<Boolean, String?>> { cont ->
                 val receiver = object : android.content.BroadcastReceiver() {
                     override fun onReceive(ctx: Context?, intent: Intent?) {


### PR DESCRIPTION
## Summary
- avoid premature timeouts when waiting for Instagram comment results

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a3558a5f48327b89a3d801b4b50c3