### PR TITLE
Add Likes V2 accessibility feature

### DIFF
--- a/socialtools_app/app/src/main/AndroidManifest.xml
+++ b/socialtools_app/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
             </intent-filter>
         </activity>
         <activity android:name=".ui.AiCommentCheckActivity" android:exported="false" />
+        <activity android:name=".ui.AiLikeCheckActivity" android:exported="false" />
         <service
             android:name=".core.services.PostService"
             android:exported="false" />
@@ -40,6 +41,17 @@
             <meta-data
                 android:name="android.accessibilityservice"
                 android:resource="@xml/instagram_comment_service" />
+        </service>
+        <service
+            android:name=".core.services.InstagramLikeService"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/instagram_like_service" />
         </service>
     </application>
 </manifest>

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/InstagramLikeService.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/InstagramLikeService.kt
@@ -1,0 +1,122 @@
+package com.cicero.socialtools.core.services
+
+import android.accessibilityservice.AccessibilityService
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+import com.cicero.socialtools.BuildConfig
+import com.cicero.socialtools.ui.MainActivity
+
+/** Accessibility service that presses the like button on Instagram posts. */
+class InstagramLikeService : AccessibilityService() {
+    private var pendingLike: Boolean = false
+
+    companion object {
+        private const val TAG = "InstagramLikeService"
+        private const val ACCESS_DELAY_MS = 3000L
+    }
+
+    private fun sendLog(message: String) {
+        val intent = Intent(MainActivity.ACTION_ACCESSIBILITY_LOG).apply {
+            putExtra(MainActivity.EXTRA_LOG_MESSAGE, message)
+        }
+        sendBroadcast(intent)
+        Log.d(TAG, message)
+    }
+
+    private fun sendResult(success: Boolean, error: String? = null) {
+        val intent = Intent(MainActivity.ACTION_LIKE_RESULT).apply {
+            putExtra(MainActivity.EXTRA_LIKE_SUCCESS, success)
+            putExtra(MainActivity.EXTRA_LIKE_ERROR, error)
+        }
+        sendBroadcast(intent)
+    }
+
+    private fun findByDesc(node: AccessibilityNodeInfo?, text: String): AccessibilityNodeInfo? {
+        if (node == null) return null
+        val desc = node.contentDescription?.toString() ?: ""
+        if (desc.contains(text, ignoreCase = true)) return node
+        for (i in 0 until node.childCount) {
+            val found = findByDesc(node.getChild(i), text)
+            if (found != null) return found
+        }
+        return null
+    }
+
+    private fun waitForRoot(maxAttempts: Int = 20): AccessibilityNodeInfo? {
+        var attempts = 0
+        var root: AccessibilityNodeInfo? = null
+        while (attempts < maxAttempts && root == null) {
+            root = rootInActiveWindow
+            if (root == null) {
+                Log.d(TAG, "Root window is null, polling...")
+                Thread.sleep(ACCESS_DELAY_MS)
+                attempts++
+            }
+        }
+        return root
+    }
+
+    private val receiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action == MainActivity.ACTION_INPUT_LIKE) {
+                pendingLike = true
+                performLike()
+            }
+        }
+    }
+
+    override fun onServiceConnected() {
+        registerReceiver(receiver, IntentFilter(MainActivity.ACTION_INPUT_LIKE))
+        sendLog("Like service connected")
+    }
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) {
+        if (event?.packageName != "com.instagram.android") return
+        if (pendingLike) {
+            Handler(Looper.getMainLooper()).postDelayed({ performLike() }, 2000)
+        }
+    }
+
+    override fun onInterrupt() {}
+
+    override fun onDestroy() {
+        unregisterReceiver(receiver)
+        sendLog("Like service destroyed")
+        super.onDestroy()
+    }
+
+    private fun performLike() {
+        if (!pendingLike) return
+        pendingLike = false
+        Thread {
+            sendLog("Starting like workflow")
+            Thread.sleep(ACCESS_DELAY_MS)
+            var root = waitForRoot(10)
+            if (BuildConfig.DEBUG) Log.d(TAG, "Root: ${'$'}root")
+            val rootNode = root ?: run {
+                val msg = "Instagram UI not ready"
+                sendLog(msg)
+                sendResult(false, msg)
+                performGlobalAction(GLOBAL_ACTION_BACK)
+                return@Thread
+            }
+            val likeBtn = findByDesc(rootNode, "Like") ?: rootNode.findAccessibilityNodeInfosByText("Like").firstOrNull()
+            if (likeBtn == null) {
+                val msg = "Like button not found"
+                sendLog(msg)
+                sendResult(false, msg)
+                return@Thread
+            }
+            likeBtn.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+            sendLog("Pressed Like button")
+            sendResult(true)
+        }.start()
+    }
+}

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -21,9 +21,11 @@ import com.cicero.socialtools.BuildConfig
 import com.cicero.socialtools.R
 import com.cicero.socialtools.ui.MainActivity
 import com.cicero.socialtools.ui.AiCommentCheckActivity
+import com.cicero.socialtools.ui.AiLikeCheckActivity
 import com.cicero.socialtools.utils.OpenAiUtils
 import com.cicero.socialtools.utils.AccessibilityUtils
 import com.cicero.socialtools.core.services.InstagramCommentService
+import com.cicero.socialtools.core.services.InstagramLikeService
 import com.github.instagram4j.instagram4j.IGClient
 import com.github.instagram4j.instagram4j.IGClient.Builder.LoginHandler
 import com.github.instagram4j.instagram4j.actions.timeline.TimelineAction
@@ -77,6 +79,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
     private lateinit var profileContainer: View
     private lateinit var startButton: Button
     private lateinit var likeCheckbox: android.widget.CheckBox
+    private lateinit var likeV2Checkbox: android.widget.CheckBox
     private lateinit var repostCheckbox: android.widget.CheckBox
     private lateinit var commentCheckbox: android.widget.CheckBox
     private lateinit var delaySeekBar: android.widget.SeekBar
@@ -229,6 +232,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
 
         startButton = view.findViewById(R.id.button_start)
         likeCheckbox = view.findViewById(R.id.checkbox_like)
+        likeV2Checkbox = view.findViewById(R.id.checkbox_like_v2)
         repostCheckbox = view.findViewById(R.id.checkbox_repost)
         commentCheckbox = view.findViewById(R.id.checkbox_comment)
         badgeView = profileView.findViewById(R.id.image_badge)
@@ -265,10 +269,11 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
             processTimeView.text = getString(R.string.loading)
 
             val doLike = likeCheckbox.isChecked
+            val doLikeV2 = likeV2Checkbox.isChecked
             val doRepost = repostCheckbox.isChecked
             val doComment = commentCheckbox.isChecked
-            if (doLike || doRepost || doComment) {
-                fetchTodayPosts(doLike, doRepost, doComment)
+            if (doLike || doLikeV2 || doRepost || doComment) {
+                fetchTodayPosts(doLike, doLikeV2, doRepost, doComment)
             } else {
                 Toast.makeText(requireContext(), "Pilih setidaknya satu aksi", Toast.LENGTH_SHORT).show()
             }
@@ -782,7 +787,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
 
 
 
-    private fun fetchTodayPosts(doLike: Boolean, doRepost: Boolean, doComment: Boolean) {
+    private fun fetchTodayPosts(doLike: Boolean, doLikeV2: Boolean, doRepost: Boolean, doComment: Boolean) {
         appendLog(
             ">>> Booting IG automation engine...",
             animate = true
@@ -855,7 +860,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                     }
                 }
                 withContext(Dispatchers.Main) {
-                    launchLogAndLikes(client, posts, doLike, doRepost, doComment)
+                    launchLogAndLikes(client, posts, doLike, doLikeV2, doRepost, doComment)
                 }
             } catch (e: Exception) {
                 withContext(Dispatchers.Main) {
@@ -869,6 +874,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
         client: IGClient,
         posts: List<PostInfo>,
         doLike: Boolean,
+        doLikeV2: Boolean,
         doRepost: Boolean,
         doComment: Boolean
     ) {
@@ -939,8 +945,60 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                 )
             }
 
+            if (doLikeV2) {
+                appendLog(
+                    ">>> Preparing like sequence...",
+                    animate = true
+                )
+                delay(2000)
+                appendLog(
+                    ">>> Executing like routine",
+                    animate = true
+                )
+                var liked = 0
+                for (post in posts.filter { !likedIds.contains(it.code) }) {
+                    appendLog("> processing target post [${post.code}]", animate = true)
+                    likeFlareAccounts(client, 5)
+                    val id = post.id
+                    val code = post.code
+                    appendLog("> checking like status for $code", animate = true)
+                    val alreadyLiked = try {
+                        withContext(Dispatchers.IO) {
+                            client.sendRequest(
+                                com.github.instagram4j.instagram4j.requests.media.MediaInfoRequest(id)
+                            ).join()
+                        }.items.firstOrNull()?.isHas_liked == true
+                    } catch (_: Exception) { false }
+                    val statusText = if (alreadyLiked) "already liked" else "not yet liked"
+                    appendLog("> status: $statusText", animate = true)
+                    if (!alreadyLiked) {
+                        try {
+                            val (ok, err) = likePostNative(code)
+                            if (ok) {
+                                appendLog("> liked post [$code]", animate = true)
+                                liked++
+                                likedIds.add(code)
+                                val prefs = requireContext().getSharedPreferences("liked", Context.MODE_PRIVATE)
+                                prefs.edit().putStringSet("ids", likedIds).apply()
+                            } else {
+                                appendLog("Error liking: ${'$'}err")
+                            }
+                        } catch (e: Exception) {
+                            appendLog("Error liking: ${e.message}")
+                        }
+                    }
+                    delay(randomDelayMs())
+                    scrollRandomFlareFeed(client)
+                    delay(randomDelayMs())
+                }
+                appendLog(
+                    ">>> Like routine finished. $liked posts liked.",
+                    animate = true
+                )
+            }
+
             if (doComment) {
-                if (doLike) {
+                if (doLike || doLikeV2) {
                     delay(actionDelayMs)
                 }
                 appendLog(
@@ -997,7 +1055,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
             }
 
             if (doRepost) {
-                if (doLike) {
+                if (doLike || doLikeV2) {
                     delay(actionDelayMs)
                 }
                 appendLog(
@@ -1315,6 +1373,75 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
                 val intent = Intent(MainActivity.ACTION_INPUT_COMMENT).apply {
                     putExtra(MainActivity.EXTRA_COMMENT, text)
                 }
+                context.sendBroadcast(intent)
+                cont.invokeOnCancellation { context.unregisterReceiver(receiver) }
+            }
+        } ?: (false to "timeout")
+
+        delay(2000)
+        val back = pm.getLaunchIntentForPackage(context.packageName)
+        back?.let { withContext(Dispatchers.Main) { startActivity(it) } }
+
+        return result
+    }
+
+    /**
+     * Opens the Instagram post for the given shortcode and presses the like button
+     * using the accessibility service.
+     */
+    private suspend fun likePostNative(shortcode: String): Pair<Boolean, String?> {
+        val uri = Uri.parse("https://www.instagram.com/p/$shortcode/")
+        val context = requireContext()
+        if (!AccessibilityUtils.isServiceEnabled(context, InstagramLikeService::class.java)) {
+            withContext(Dispatchers.Main) {
+                startActivity(Intent(context, AiLikeCheckActivity::class.java))
+            }
+            return false to "service disabled"
+        }
+        val pm = context.packageManager
+        val appIntent = Intent(Intent.ACTION_VIEW, uri).apply {
+            setPackage("com.instagram.android")
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        val canUseApp = appIntent.resolveActivity(pm) != null
+        withContext(Dispatchers.Main) {
+            if (canUseApp) {
+                startActivity(appIntent)
+            } else {
+                startActivity(Intent(Intent.ACTION_VIEW, uri).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                })
+                Toast.makeText(
+                    context,
+                    "Instagram app not found, opening in browser",
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+        }
+        if (!canUseApp) return false to "instagram app missing"
+
+        delay(10000)
+
+        val result = withTimeoutOrNull(60000) {
+            suspendCancellableCoroutine<Pair<Boolean, String?>> { cont ->
+                val receiver = object : android.content.BroadcastReceiver() {
+                    override fun onReceive(ctx: Context?, intent: Intent?) {
+                        if (intent?.action == MainActivity.ACTION_LIKE_RESULT) {
+                            ctx?.unregisterReceiver(this)
+                            val success = intent.getBooleanExtra(
+                                MainActivity.EXTRA_LIKE_SUCCESS,
+                                false
+                            )
+                            val error = intent.getStringExtra(MainActivity.EXTRA_LIKE_ERROR)
+                            if (cont.isActive) cont.resume(success to error) {}
+                        }
+                    }
+                }
+                context.registerReceiver(
+                    receiver,
+                    android.content.IntentFilter(MainActivity.ACTION_LIKE_RESULT)
+                )
+                val intent = Intent(MainActivity.ACTION_INPUT_LIKE)
                 context.sendBroadcast(intent)
                 cont.invokeOnCancellation { context.unregisterReceiver(receiver) }
             }

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/AiLikeCheckActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/AiLikeCheckActivity.kt
@@ -1,0 +1,31 @@
+package com.cicero.socialtools.ui
+
+import android.content.Intent
+import android.os.Bundle
+import android.provider.Settings
+import android.widget.Button
+import androidx.appcompat.app.AppCompatActivity
+import com.cicero.socialtools.R
+import com.cicero.socialtools.core.services.InstagramLikeService
+import com.cicero.socialtools.utils.AccessibilityUtils
+
+/** Screen that links to accessibility settings so the user can enable the like service. */
+class AiLikeCheckActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_ai_like_check)
+
+        findViewById<Button>(R.id.button_open_settings).setOnClickListener {
+            startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (!AccessibilityUtils.isServiceEnabled(this, InstagramLikeService::class.java)) {
+            startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+        } else {
+            finish()
+        }
+    }
+}

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/MainActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/MainActivity.kt
@@ -17,6 +17,10 @@ class MainActivity : AppCompatActivity() {
         const val ACTION_COMMENT_RESULT = "com.cicero.socialtools.COMMENT_RESULT"
         const val EXTRA_COMMENT_SUCCESS = "extra_success"
         const val EXTRA_COMMENT_ERROR = "extra_error"
+        const val ACTION_INPUT_LIKE = "com.cicero.socialtools.INPUT_LIKE"
+        const val ACTION_LIKE_RESULT = "com.cicero.socialtools.LIKE_RESULT"
+        const val EXTRA_LIKE_SUCCESS = "extra_like_success"
+        const val EXTRA_LIKE_ERROR = "extra_like_error"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/socialtools_app/app/src/main/res/layout/activity_ai_like_check.xml
+++ b/socialtools_app/app/src/main/res/layout/activity_ai_like_check.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/text_info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Enable the accessibility service to allow automatic likes." />
+
+    <Button
+        android:id="@+id/button_open_settings"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Open Accessibility Settings" />
+</LinearLayout>

--- a/socialtools_app/app/src/main/res/layout/fragment_instagram_tools.xml
+++ b/socialtools_app/app/src/main/res/layout/fragment_instagram_tools.xml
@@ -120,6 +120,14 @@
                 android:checked="false" />
 
             <CheckBox
+                android:id="@+id/checkbox_like_v2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Likes V2"
+                android:checked="false"
+                android:layout_marginStart="16dp" />
+
+            <CheckBox
                 android:id="@+id/checkbox_repost"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/socialtools_app/app/src/main/res/xml/instagram_like_service.xml
+++ b/socialtools_app/app/src/main/res/xml/instagram_like_service.xml
@@ -1,0 +1,5 @@
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:packageNames="com.instagram.android"
+    android:description="@string/service_description" />


### PR DESCRIPTION
## Summary
- add checkbox for Like V2 on Instagram tools screen
- create a new accessibility service `InstagramLikeService`
- add activity to prompt enabling the like service
- wire up Like V2 workflow that mirrors the original like routine but uses the accessibility service
- update manifest and constants

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686a3c0fddac83279b7916dce7e7f78b