### PR TITLE
Remove UI delay control and randomize waiting time

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsFragment.kt
@@ -82,9 +82,8 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
     private lateinit var likeV2Checkbox: android.widget.CheckBox
     private lateinit var repostCheckbox: android.widget.CheckBox
     private lateinit var commentCheckbox: android.widget.CheckBox
-    private lateinit var delaySeekBar: android.widget.SeekBar
-    private lateinit var delayText: TextView
-    private var actionDelayMs: Long = 30000L
+    // Removed user-configurable delay UI
+    private fun randomActionDelayMs(): Long = Random.nextLong(30000L, 60000L)
     private val uploadDelayMs: Long = 10000L
     private val videoUploadExtraDelayMs: Long = 90000L
     private val postDelayMs: Long = 120000L
@@ -212,22 +211,6 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
 
         // Removed Twitter and TikTok containers
         targetLinkInput = view.findViewById(R.id.input_target_link)
-
-        delaySeekBar = view.findViewById(R.id.seekbar_delay)
-        delayText = view.findViewById(R.id.text_delay_value)
-        actionDelayMs = delaySeekBar.progress * 1000L
-        delayText.text =
-            "Delay: ${delaySeekBar.progress} detik"
-        delaySeekBar.setOnSeekBarChangeListener(object : android.widget.SeekBar.OnSeekBarChangeListener {
-            override fun onProgressChanged(seekBar: android.widget.SeekBar?, progress: Int, fromUser: Boolean) {
-                actionDelayMs = progress * 1000L
-                delayText.text = "Delay: $progress detik"
-            }
-
-            override fun onStartTrackingTouch(seekBar: android.widget.SeekBar?) {}
-
-            override fun onStopTrackingTouch(seekBar: android.widget.SeekBar?) {}
-        })
 
 
         startButton = view.findViewById(R.id.button_start)
@@ -999,7 +982,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
 
             if (doComment) {
                 if (doLike || doLikeV2) {
-                    delay(actionDelayMs)
+                    delay(randomActionDelayMs())
                 }
                 appendLog(
                     ">>> Preparing comment sequence...",
@@ -1056,7 +1039,7 @@ class InstagramToolsFragment : Fragment(R.layout.fragment_instagram_tools) {
 
             if (doRepost) {
                 if (doLike || doLikeV2) {
-                    delay(actionDelayMs)
+                    delay(randomActionDelayMs())
                 }
                 appendLog(
                     ">>> Initiating environment for re-post ops...",

--- a/socialtools_app/app/src/main/res/layout/fragment_instagram_tools.xml
+++ b/socialtools_app/app/src/main/res/layout/fragment_instagram_tools.xml
@@ -144,29 +144,7 @@
                 android:layout_marginStart="16dp" />
         </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:paddingStart="16dp"
-            android:paddingEnd="16dp">
 
-            <SeekBar
-                android:id="@+id/seekbar_delay"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:min="30"
-                android:max="600"
-                android:progress="30" />
-
-            <TextView
-                android:id="@+id/text_delay_value"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:paddingTop="4dp"
-                android:text="Delay: 30 detik" />
-        </LinearLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- remove delay SeekBar from Instagram tools layout
- drop delay SeekBar handling code
- use a random delay between 30s and 60s when switching actions

## Testing
- `./gradlew test` *(fails: Unable to access jarfile gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686a40350d388327983f9b4a36f9e14a