### PR TITLE
Fix TextView context usage

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
@@ -517,7 +517,7 @@ class InstagramToolsActivity : AppCompatActivity() {
         animate: Boolean = false
     ) {
         lifecycleScope.launch(Dispatchers.Main) {
-            val tv = TextView(this).apply {
+            val tv = TextView(this@InstagramToolsActivity).apply {
                 typeface = android.graphics.Typeface.MONOSPACE
                 setTextColor(android.graphics.Color.parseColor("#00FF00"))
             }


### PR DESCRIPTION
## Summary
- fix `TextView(this)` to use the activity context

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a50774bb48327be8ae9b6278d30b1