### PR TITLE
Fix login screen layout namespace

### DIFF
--- a/socialtools_app/app/src/main/res/layout/activity_login.xml
+++ b/socialtools_app/app/src/main/res/layout/activity_login.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fillViewport="true"


### PR DESCRIPTION
## Summary
- add the missing `app` namespace to the login layout

## Testing
- `gradle test --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a592595bc8327a2f94da065bb661c