### PR TITLE
Handle existing IG sessions on launch

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/LandingActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/ui/LandingActivity.kt
@@ -5,6 +5,8 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import android.widget.Button
 import com.cicero.socialtools.R
+import com.cicero.socialtools.features.instagram.InstagramToolsActivity
+import java.io.File
 
 /** Simple landing page displayed on app launch. */
 class LandingActivity : AppCompatActivity() {
@@ -20,6 +22,14 @@ class LandingActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val clientFile = File(filesDir, "igclient.ser")
+        val cookieFile = File(filesDir, "igcookie.ser")
+        if (clientFile.exists() && cookieFile.exists()) {
+            startActivity(Intent(this, InstagramToolsActivity::class.java))
+            finish()
+            return
+        }
+
         setContentView(R.layout.activity_landing)
 
         findViewById<Button>(R.id.button_start).setOnClickListener {


### PR DESCRIPTION
## Summary
- check for serialized Instagram session files on app launch
- skip the landing page when a session exists and jump straight to Instagram tools

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686a5f3d643c83278145aa558b8dc49e