### PR TITLE
Add comprehensive setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,6 @@ To build the app:
 cd socialtools_app
 ./gradlew assembleDebug
 ```
+
+For a full walkthrough of the setup process, including submodule initialization,
+see [docs/SETUP.md](docs/SETUP.md).

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,35 @@
+# Setup Guide
+
+This document explains how to configure the project on a new machine.
+
+## Clone the repository
+
+```bash
+git clone https://github.com/your-user/CiceroAutoPost.git
+cd CiceroAutoPost
+```
+
+Initialize the submodules so that `instagram4j` is available:
+
+```bash
+git submodule update --init --recursive
+```
+
+## Environment
+
+Create a `.env` file in the root directory:
+
+```bash
+OPENAI_API_KEY=sk-...
+```
+
+## Build the app
+
+Use the Gradle wrapper to compile the debug APK:
+
+```bash
+cd socialtools_app
+./gradlew assembleDebug
+```
+
+The wrapper script will automatically download the required Gradle files if they are not present.


### PR DESCRIPTION
## Summary
- document project setup steps in new docs/SETUP.md
- link setup instructions from README

## Testing
- `./socialtools_app/gradlew help` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_686a796d25448327acc77c61756bc01e