### PR TITLE
Fix unmatched brace in InstagramToolsActivity

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
@@ -639,7 +639,6 @@ class InstagramToolsActivity : AppCompatActivity() {
         }
     }
 
-    }
 
     @Deprecated("Deprecated in Java")
     override fun onOptionsItemSelected(item: android.view.MenuItem): Boolean {


### PR DESCRIPTION
## Summary
- remove stray closing brace in InstagramToolsActivity

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686bacdd4f488327a2a76a3086629fe3