### PR TITLE
Fix unresolved reference in InstagramToolsActivity

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
@@ -682,4 +682,14 @@ class InstagramToolsActivity : AppCompatActivity() {
             startService(intent)
         }
     }
+
+    /**
+     * Previous versions performed automated like and repost actions here.
+     * The full implementation was removed, but the start button still
+     * expects this entry point. For now we simply log a placeholder
+     * so the app can compile without the legacy workflow.
+     */
+    private fun fetchTodayPosts(doLike: Boolean, doRepost: Boolean, doComment: Boolean) {
+        appendLog("> IG automation has been disabled in this build")
+    }
 }


### PR DESCRIPTION
## Summary
- add placeholder implementation for `fetchTodayPosts`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686badd5e5748327bc5f7e622e0e863f