### PR TITLE
Fix InstagramToolsActivity compilation issues

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
@@ -639,8 +639,6 @@ class InstagramToolsActivity : AppCompatActivity() {
         }
     }
 
-    }
-
     @Deprecated("Deprecated in Java")
     override fun onOptionsItemSelected(item: android.view.MenuItem): Boolean {
         return when (item.itemId) {
@@ -682,5 +680,15 @@ class InstagramToolsActivity : AppCompatActivity() {
         } else {
             startService(intent)
         }
+    }
+
+    /**
+     * Previous versions performed automated like and repost actions here.
+     * The full implementation was removed, but the start button still
+     * expects this entry point. For now we simply log a placeholder
+     * so the app can compile without the legacy workflow.
+     */
+    private fun fetchTodayPosts(doLike: Boolean, doRepost: Boolean, doComment: Boolean) {
+        appendLog("> IG automation has been disabled in this build")
     }
 }


### PR DESCRIPTION
## Summary
- remove stray brace in InstagramToolsActivity
- restore `fetchTodayPosts` stub so the start button compiles

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686bb5ea90648327a65eac99231441ee