### PR TITLE
Match input and start button heights

### DIFF
--- a/socialtools_app/app/src/main/res/layout/activity_instagram_tools.xml
+++ b/socialtools_app/app/src/main/res/layout/activity_instagram_tools.xml
@@ -62,7 +62,7 @@
         <AutoCompleteTextView
             android:id="@+id/input_target_link"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="@dimen/standard_input_height"
             android:inputType="textUri"
             android:importantForAutofill="yes"
             android:contentDescription="@string/link_target" />
@@ -71,7 +71,7 @@
     <Button
         android:id="@+id/button_start"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="@dimen/standard_input_height"
         android:text="Start"
         android:layout_margin="16dp" />
 

--- a/socialtools_app/app/src/main/res/values/dimens.xml
+++ b/socialtools_app/app/src/main/res/values/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="standard_input_height">48dp</dimen>
+</resources>


### PR DESCRIPTION
## Summary
- add a new `standard_input_height` dimension
- use the same height on the target link text box and start button

## Testing
- `./gradlew test --console=plain` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_686bcee408c083278f7bcf6a41ddd8fc