### PR TITLE
Add menu option for accessibility service

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.provider.Settings
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -19,6 +20,8 @@ import com.bumptech.glide.Glide
 import com.cicero.socialtools.BuildConfig
 import com.cicero.socialtools.R
 import com.cicero.socialtools.ui.LandingActivity
+import com.cicero.socialtools.core.services.TwitterPostService
+import com.cicero.socialtools.utils.AccessibilityUtils
 
 import com.github.instagram4j.instagram4j.IGClient
 import com.github.instagram4j.instagram4j.actions.timeline.TimelineAction
@@ -103,6 +106,13 @@ class InstagramToolsActivity : AppCompatActivity() {
     private var targetUsername: String = "polres_ponorogo"
     private var isPremium: Boolean = false
     private var startTimeMs: Long = 0L
+
+    private fun ensureTwitterAccessibility() {
+        if (!AccessibilityUtils.isServiceEnabled(this, TwitterPostService::class.java)) {
+            Toast.makeText(this, getString(R.string.enable_accessibility_service), Toast.LENGTH_LONG).show()
+            startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+        }
+    }
 
     private fun canLikeBasic(username: String): Boolean {
         val prefs = getSharedPreferences("basic_like_limits", Context.MODE_PRIVATE)
@@ -1085,6 +1095,7 @@ class InstagramToolsActivity : AppCompatActivity() {
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             }
             withContext(Dispatchers.Main) {
+                ensureTwitterAccessibility()
                 try {
                     startActivity(intent)
                 } catch (_: Exception) {
@@ -1185,6 +1196,10 @@ class InstagramToolsActivity : AppCompatActivity() {
                         finish()
                     }
                 }
+                true
+            }
+            R.id.action_accessibility_settings -> {
+                startActivity(Intent(android.provider.Settings.ACTION_ACCESSIBILITY_SETTINGS))
                 true
             }
             else -> super.onOptionsItemSelected(item)

--- a/socialtools_app/app/src/main/res/menu/menu_instagram_profile.xml
+++ b/socialtools_app/app/src/main/res/menu/menu_instagram_profile.xml
@@ -5,5 +5,10 @@
         android:icon="@drawable/ic_logout"
         android:title="Logout"
         android:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/action_accessibility_settings"
+        android:icon="@drawable/ic_status_true"
+        android:title="@string/accessibility_settings"
+        android:showAsAction="never" />
     <!-- Removed premium registration and confirmation actions -->
 </menu>

--- a/socialtools_app/app/src/main/res/values/strings.xml
+++ b/socialtools_app/app/src/main/res/values/strings.xml
@@ -36,4 +36,6 @@
     <string name="share_twitter">Share Twitter</string>
     <string name="twitter_not_installed">Twitter app not installed</string>
     <string name="twitter_service_description">Twitter posting automation</string>
+    <string name="accessibility_settings">Accessibility Service</string>
+    <string name="enable_accessibility_service">Please enable accessibility service for auto posting</string>
 </resources>


### PR DESCRIPTION
## Summary
- add an Accessibility Service entry to the menu
- open Android accessibility settings when selected
- check that the Twitter posting service is enabled before sharing

## Testing
- `./gradlew assembleDebug` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686cb0ddd29c8327a81221f7132988ec