### PR TITLE
Implement delay before Twitter posts

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
@@ -1094,6 +1094,7 @@ class InstagramToolsActivity : AppCompatActivity() {
                 setPackage("com.twitter.android")
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             }
+            delay(3000)
             withContext(Dispatchers.Main) {
                 ensureTwitterAccessibility()
                 try {


### PR DESCRIPTION
## Summary
- add a 3-second delay before launching the Twitter share intent

## Testing
- `./gradlew tasks --no-daemon` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_686cb7c6a8048327a80527b59616aa4e