### PR TITLE
Fix TikTok share for alternate package

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/TiktokPostService.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/core/services/TiktokPostService.kt
@@ -20,7 +20,10 @@ class TiktokPostService : AccessibilityService() {
 
     override fun onServiceConnected() {
         serviceInfo = AccessibilityServiceInfo().apply {
-            packageNames = arrayOf("com.zhiliaoapp.musically")
+            packageNames = arrayOf(
+                "com.zhiliaoapp.musically",
+                "com.ss.android.ugc.trill"
+            )
             eventTypes = AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED or
                     AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED
             feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC

--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
@@ -1163,10 +1163,25 @@ class InstagramToolsActivity : AppCompatActivity() {
                 "${BuildConfig.APPLICATION_ID}.fileprovider",
                 video
             )
+            val packages = arrayOf("com.zhiliaoapp.musically", "com.ss.android.ugc.trill")
+            val installedPackage = packages.firstOrNull { pkg ->
+                packageManager.getLaunchIntentForPackage(pkg) != null
+            }
+            if (installedPackage == null) {
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(
+                        this@InstagramToolsActivity,
+                        getString(R.string.tiktok_not_installed),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                    appendLog("TikTok app not installed")
+                }
+                return@launch
+            }
             val intent = Intent(Intent.ACTION_SEND).apply {
                 type = "video/*"
                 putExtra(Intent.EXTRA_STREAM, uri)
-                setPackage("com.zhiliaoapp.musically")
+                setPackage(installedPackage)
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             }
             delay(3000)

--- a/socialtools_app/app/src/main/res/xml/tiktok_service_config.xml
+++ b/socialtools_app/app/src/main/res/xml/tiktok_service_config.xml
@@ -1,6 +1,6 @@
 <accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
     android:accessibilityEventTypes="typeWindowContentChanged|typeWindowStateChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
-    android:packageNames="com.zhiliaoapp.musically"
+    android:packageNames="com.zhiliaoapp.musically,com.ss.android.ugc.trill"
     android:canRetrieveWindowContent="true"
     android:description="@string/tiktok_service_description"/>


### PR DESCRIPTION
## Summary
- support multiple TikTok package names when launching share intent
- update accessibility service package list

## Testing
- `gradle -q help --dry-run`
- `gradle -q lint --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce547eb688327b7b5faee964decf5