### PR TITLE
Fix TikTok share intent

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
@@ -3,6 +3,7 @@ package com.cicero.socialtools.features.instagram
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.content.ComponentName
 import android.net.Uri
 import android.provider.Settings
 import android.os.Bundle
@@ -1183,6 +1184,18 @@ class InstagramToolsActivity : AppCompatActivity() {
                 putExtra(Intent.EXTRA_STREAM, uri)
                 setPackage(installedPackage)
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            // Prefer the TikTok share activity labeled "Video" if available
+            val pm = packageManager
+            val targets = pm.queryIntentActivities(intent, 0)
+            val videoActivity = targets.firstOrNull { info ->
+                info.loadLabel(pm).toString().contains("video", ignoreCase = true)
+            }
+            if (videoActivity != null) {
+                intent.component = ComponentName(
+                    videoActivity.activityInfo.packageName,
+                    videoActivity.activityInfo.name
+                )
             }
             delay(3000)
             withContext(Dispatchers.Main) {


### PR DESCRIPTION
## Summary
- ensure that when sharing to TikTok we prefer the activity labeled "Video"

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686cea50754883279f4c9f23dd257bc8