### PR TITLE
Remove logout button from profile layout

### DIFF
--- a/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
+++ b/socialtools_app/app/src/main/java/com/cicero/socialtools/features/instagram/InstagramToolsActivity.kt
@@ -269,7 +269,6 @@ class InstagramToolsActivity : AppCompatActivity() {
         followingView = profileView.findViewById(R.id.stat_following)
         profileView.findViewById<View>(R.id.text_nrp).visibility = View.GONE
         profileView.findViewById<View>(R.id.info_container).visibility = View.GONE
-        profileView.findViewById<Button>(R.id.button_logout).visibility = View.GONE
 
         // Removed Twitter and TikTok containers
         targetLinkInput = findViewById(R.id.input_target_link)

--- a/socialtools_app/app/src/main/res/layout/activity_profile.xml
+++ b/socialtools_app/app/src/main/res/layout/activity_profile.xml
@@ -259,14 +259,5 @@
 
         </LinearLayout>
 
-        <Button
-            android:id="@+id/button_logout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/logout"
-            android:layout_marginTop="24dp"
-            app:layout_constraintTop_toBottomOf="@id/info_container"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/socialtools_app/app/src/main/res/values/strings.xml
+++ b/socialtools_app/app/src/main/res/values/strings.xml
@@ -8,7 +8,6 @@
     <string name="satfung">Satfung</string>
     <string name="jabatan">Jabatan</string>
     <string name="username_tiktok">Username TikTok</string>
-    <string name="logout">Logout</string>
     <string name="todo">TODO</string>
     <string name="_0">0</string>
     <string name="nama">Nama</string>


### PR DESCRIPTION
## Summary
- remove the logout button from `activity_profile.xml`
- clean up reference in `InstagramToolsActivity`
- drop unused `logout` string resource

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68784e3a6a4483278ca22b4e6d97639e